### PR TITLE
read-only-mode new in Emacs 24.3, provide fallback for older version.

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -289,8 +289,8 @@ recognizes, so that the user may jump to the results."
     (let ((inhibit-read-only t))
       ;; read-only-mode new in Emacs 24.3
       (if (fboundp 'read-only-mode)
-	  (read-only-mode nil)
-	(setq buffer-read-only nil))
+          (read-only-mode nil)
+        (setq buffer-read-only nil))
       (erase-buffer)
 
       (when (not (null header))
@@ -302,8 +302,8 @@ recognizes, so that the user may jump to the results."
             lines-to-write)
       (compilation-mode)
       (if (fboundp 'read-only-mode)
-	  (read-only-mode t)
-	(setq buffer-read-only t))
+          (read-only-mode t)
+        (setq buffer-read-only t))
       (display-buffer buffer-to-write-to))))
 
 (defun omnisharp--find-usages-output-to-compilation-output


### PR DESCRIPTION
omnisharp-find-usages doesn't work in Emacsen pre 24.3 (I'm running 24.2 currently) as read-only-mode is new in that version.

I don't know how bothered you are about supporting slight older versions, but this change provides a fallback if read-only-mode isn't defined.
