### PR TITLE
added safeguards so host without ending slash does not crash things

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -202,11 +202,17 @@ server backend."
     ["Run code format on current buffer" omnisharp-code-format]
     ))
 
+(defun omnisharp-get-host ()
+	"Makes sure omnisharp-host is ended by / "
+	(if (string= (substring omnisharp-host -1 ) "/")
+			omnisharp-host
+		(concat omnisharp-host "/")))
+
 (defun omnisharp-reload-solution ()
   "Reload the current solution."
   (interactive)
   (omnisharp-post-message-curl
-   (concat omnisharp-host "reloadsolution")
+   (concat (omnisharp-get-host) "reloadsolution")
    ;; no params needed
    nil))
 
@@ -215,7 +221,7 @@ server backend."
 argument, use another window."
   (interactive "P")
   (let* ((json-result (omnisharp-post-message-curl-as-json
-                       (concat omnisharp-host "gotodefinition")
+                       (concat (omnisharp-get-host) "gotodefinition")
                        (omnisharp--get-common-params)))
          (filename (cdr (assoc 'FileName json-result))))
     (if (null filename)
@@ -245,7 +251,7 @@ argument, use another window."
 (defun omnisharp-find-usages-worker (request)
   ;; TODO make this asyncronic like all other compilation processes!
   (let* ((quickfix-response (omnisharp-post-message-curl-as-json
-                             (concat omnisharp-host "findusages")
+                             (concat (omnisharp-get-host) "findusages")
                              request))
          (quickfixes (omnisharp--vector-to-list
                       (cdr (assoc 'QuickFixes quickfix-response)))))
@@ -269,7 +275,7 @@ to select one (or more) to jump to."
   "Returns a list of QuickFix lisp objects from a findimplementations
 api call made with the given Request."
   (let* ((quickfix-response (omnisharp-post-message-curl-as-json
-                             (concat omnisharp-host "findimplementations")
+                             (concat (omnisharp-get-host) "findimplementations")
                              request))
          (quickfixes (omnisharp--vector-to-list
                       (cdr (assoc 'QuickFixes quickfix-response)))))
@@ -282,7 +288,7 @@ use another window."
   (interactive "P")
   (let ((quickfix-response
          (omnisharp-post-message-curl-as-json
-          (concat omnisharp-host "gotoregion")
+          (concat (omnisharp-get-host) "gotoregion")
           (omnisharp--get-common-params))))
     (omnisharp--choose-and-go-to-quickfix-ido
      (cdr (assoc 'QuickFixes quickfix-response))
@@ -326,7 +332,7 @@ name to rename to, defaulting to the current name of the symbol."
 objects."
   (let* ((rename-responses
           (omnisharp-post-message-curl-as-json
-           (concat omnisharp-host "rename")
+           (concat (omnisharp-get-host) "rename")
            rename-request))
          (modified-files (omnisharp--vector-to-list
                           (cdr (assoc 'Changes rename-responses)))))
@@ -438,7 +444,7 @@ follow results to the locations in the actual files."
   "Stop the current omnisharp instance."
   (interactive)
   (omnisharp-post-message-curl
-   (concat omnisharp-host "stopserver")
+   (concat (omnisharp-get-host) "stopserver")
    nil))
 
 ;; TODO create omnisharp-add-to-solution that lets user choose which
@@ -466,7 +472,7 @@ follow results to the locations in the actual files."
   "TODO"
   ;; TODO report results somehow
   (omnisharp-post-message-curl
-   (concat omnisharp-host "addtoproject")
+   (concat (omnisharp-get-host) "addtoproject")
    params))
 
 (defun omnisharp-remove-from-project-current-file ()
@@ -491,7 +497,7 @@ solution."
 
 (defun omnisharp-remove-from-project-current-file-worker (params)
   (omnisharp-post-message-curl
-   (concat omnisharp-host "removefromproject")
+   (concat (omnisharp-get-host) "removefromproject")
    params))
 
 (defun omnisharp-add-reference ()
@@ -512,7 +518,7 @@ solution."
 
 (defun omnisharp-add-reference-worker (params)
   (omnisharp-post-message-curl-as-json
-   (concat omnisharp-host "addreference")
+   (concat (omnisharp-get-host) "addreference")
    params))
 
 (defun omnisharp-auto-complete ()
@@ -764,7 +770,7 @@ Returns the raw JSON result. Also caches that result as
 omnisharp--last-buffer-specific-auto-complete-result."
   (let ((json-result
          (omnisharp-post-message-curl-as-json
-          (concat omnisharp-host "autocomplete")
+          (concat (omnisharp-get-host) "autocomplete")
           auto-complete-request)))
     ;; Cache result so it may be juggled in different contexts easily
     (setq omnisharp--last-buffer-specific-auto-complete-result
@@ -779,7 +785,7 @@ omnisharp--last-buffer-specific-auto-complete-result."
   (let* ((json-result
           (omnisharp--vector-to-list
            (omnisharp-post-message-curl-as-json
-            (concat omnisharp-host "getoverridetargets")
+            (concat (omnisharp-get-host) "getoverridetargets")
             params)))
          (target-names
           (mapcar (lambda (a)
@@ -799,7 +805,7 @@ omnisharp--last-buffer-specific-auto-complete-result."
 
 (defun omnisharp-auto-complete-overrides-run-override-worker (params)
   (let ((json-result (omnisharp-post-message-curl-as-json
-                      (concat omnisharp-host "runoverridetarget")
+                      (concat (omnisharp-get-host) "runoverridetarget")
                       params)))
     (omnisharp--set-buffer-contents-to
      (cdr (assoc 'FileName json-result))
@@ -841,7 +847,7 @@ user is less likely to lose data."
   "Fetches and returns a GetCodeActionsResponse: the runnable
 refactoring code actions for the current file and position."
   (omnisharp-post-message-curl-as-json
-   (concat omnisharp-host "getcodeactions")
+   (concat (omnisharp-get-host) "getcodeactions")
    (omnisharp--get-common-params)))
 
 (defun omnisharp-run-code-action-refactoring-worker
@@ -852,7 +858,7 @@ refactoring code actions for the current file and position."
                 (omnisharp--get-common-params)))
          (json-run-action-result ; RunCodeActionsResponse
           (omnisharp-post-message-curl-as-json
-           (concat omnisharp-host "runcodeaction")
+           (concat (omnisharp-get-host) "runcodeaction")
            run-action-params)))
 
     (omnisharp-run-code-action-worker run-action-params
@@ -1248,7 +1254,7 @@ to insert the result in code, for example."
 PARAMS as a single human-readable string."
   (let ((json-result
          (omnisharp-post-message-curl-as-json
-          (concat omnisharp-host "typelookup")
+          (concat (omnisharp-get-host) "typelookup")
           params)))
     (cdr (assoc 'Type json-result))))
 
@@ -1261,7 +1267,7 @@ ring."
 (defun omnisharp-get-build-command ()
   "Retrieve the shell command to build the current solution."
   (omnisharp-post-message-curl
-   (concat omnisharp-host "buildcommand")
+   (concat (omnisharp-get-host) "buildcommand")
    nil))
 
 (defun omnisharp-build-in-emacs ()
@@ -1342,7 +1348,7 @@ with the formatted result. Saves the file before starting."
                                      current-column)
   (let ((json-result
          (omnisharp-post-message-curl-as-json
-          (concat omnisharp-host "codeformat")
+          (concat (omnisharp-get-host) "codeformat")
           code-format-request)))
     (omnisharp--set-buffer-contents-to
      filename
@@ -1356,7 +1362,7 @@ with the formatted result. Saves the file before starting."
 (defun omnisharp-syntax-check-worker (params)
   "Takes a Request and returns a SyntaxErrorsResponse."
   (omnisharp-post-message-curl-as-json
-   (concat omnisharp-host "syntaxerrors")
+   (concat (omnisharp-get-host) "syntaxerrors")
    params))
 
 (flycheck-define-checker csharp-omnisharp-curl
@@ -1368,7 +1374,7 @@ type errors."
   :command ((eval
              (let ((command-plist
                     (omnisharp--get-curl-command
-                     (concat omnisharp-host "syntaxerrors")
+                     (concat (omnisharp-get-host) "syntaxerrors")
                      (omnisharp--get-common-params))))
                (cons
                 (plist-get command-plist :command)
@@ -1429,7 +1435,7 @@ cursor at that location"
   "Imenu callback function - returns an alist of ((member-name . position))"
   (interactive)
   (let* ((quickfixes (omnisharp-post-message-curl-as-json
-                      (concat omnisharp-host "currentfilemembersasflat")
+                      (concat (omnisharp-get-host) "currentfilemembersasflat")
                       (omnisharp--get-common-params)))
          (list-quickfixes (omnisharp--vector-to-list quickfixes))
          (imenu-list (mapcar (lambda (quickfix-alist)
@@ -1455,7 +1461,7 @@ selected member. With prefix argument, use another window."
 (defun omnisharp-navigate-to-current-file-member-worker
   (request &optional other-window)
   (let ((quickfixes (omnisharp-post-message-curl-as-json
-                     (concat omnisharp-host "currentfilemembersasflat")
+                     (concat (omnisharp-get-host) "currentfilemembersasflat")
                      request)))
     (omnisharp--choose-and-go-to-quickfix-ido
      quickfixes
@@ -1512,7 +1518,7 @@ ido-completing-read. Returns the chosen element."
 (defun omnisharp-navigate-to-type-in-current-file-worker (request)
   (let ((quickfixes
          (omnisharp-post-message-curl-as-json
-          (concat omnisharp-host "currentfiletopleveltypes")
+          (concat (omnisharp-get-host) "currentfiletopleveltypes")
           request)))
     (omnisharp--choose-and-go-to-quickfix-ido
      quickfixes)))
@@ -1523,7 +1529,7 @@ ido-completing-read. Returns the chosen element."
   (interactive "P")
   (let ((quickfix-response
          (omnisharp-post-message-curl-as-json
-          (concat omnisharp-host "findsymbols")
+          (concat (omnisharp-get-host) "findsymbols")
           nil)))
     (omnisharp--choose-and-go-to-quickfix-ido
      (omnisharp--vector-to-list
@@ -1547,7 +1553,7 @@ ido-completing-read. Returns the chosen element."
   "Return a QuickFixResponse containing a list of all locations of
 files in the current solution."
   (omnisharp-post-message-curl-as-json
-   (concat omnisharp-host "gotofile")
+   (concat (omnisharp-get-host) "gotofile")
    nil))
 
 (defun omnisharp--get-solution-files-list-of-strings ()
@@ -1581,7 +1587,7 @@ use another window."
   (interactive "P")
   (let ((quickfix-response
          (omnisharp-post-message-curl-as-json
-          (concat omnisharp-host "gotoregion")
+          (concat (omnisharp-get-host) "gotoregion")
           (omnisharp--get-common-params))))
     (omnisharp--choose-and-go-to-quickfix-ido
      (cdr (assoc 'QuickFixes quickfix-response))
@@ -1602,7 +1608,7 @@ current buffer. Use this in your csharp-mode hook."
   (interactive)
   (let ((quickfix-response
          (omnisharp-post-message-curl-as-json
-          (concat omnisharp-host "gotoregion")
+          (concat (omnisharp-get-host) "gotoregion")
           (omnisharp--get-common-params))))
     (omnisharp--choose-and-go-to-quickfix-ido
      (cdr (assoc 'QuickFixes quickfix-response)))))


### PR DESCRIPTION
After I had changed some variables to be things that could be customized I realized that the user could easally be tripped up by the requirement that the host variables needs to have a ending slash, this solves that problem, by checking the variables before use and in case it's missing a slash adding it.
