### PR TITLE
fix for new backend changes. Pass forward slash on Unix

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -1134,8 +1134,7 @@ is a more sophisticated matching framework than what popup.el offers."
   (let* ((line-number (number-to-string (line-number-at-pos)))
          (column-number (number-to-string (+ 1 (omnisharp--current-column))))
          (buffer-contents (omnisharp--get-current-buffer-contents))
-         (filename-tmp (omnisharp--convert-slashes-to-double-backslashes
-                        (or buffer-file-name "")))
+         (filename-tmp (or buffer-file-name ""))
          (params `((Line     . ,line-number)
                    (Column   . ,column-number)
                    (Buffer   . ,buffer-contents))))


### PR DESCRIPTION
I made a change to the server that requires that you pass in the native separator (depending on platform) rather than backslashes.

This change seems to work for me, but I know nothing about elisp or your code base :) 

Sorry about this... I only just realised that omnisharp-emacs was broken against the latest server. Until this is merged, you will need to use server at SHA 512f7666fa.
