### PR TITLE
Quote server and solution file paths to support spaces in paths

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -1816,6 +1816,10 @@ result."
   (when (eq nil server-exe-file-path)
     (setq server-exe-file-path
           omnisharp-server-executable-path))
+  (setq server-exe-file-path (shell-quote-argument
+                              (expand-file-name server-exe-file-path)))
+  (setq solution-file-path (shell-quote-argument
+                              (expand-file-name solution-file-path)))
   (cond
    ((equal system-type 'windows-nt)
     (concat server-exe-file-path " -s " solution-file-path " > NUL"))


### PR DESCRIPTION
If the server path or solution file paths have spaces, then starting the server will fail. I fixed this using shell-quote-argument and expand-file-name.
