### PR TITLE
Fix compile errors and warnings

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -1871,8 +1871,9 @@ port specified."
     (message "Server is not alive")))
 
 (defun omnisharp--check-alive-status-worker ()
-  (omnisharp-post-message-curl-as-json
-   (concat (omnisharp-get-host) "checkalivestatus")))
+  (let ((result (omnisharp-post-message-curl-as-json
+		 (concat (omnisharp-get-host) "checkalivestatus"))))
+    (eq result t)))
 
 ;;;###autoload
 (defun omnisharp-check-ready-status ()
@@ -1885,8 +1886,9 @@ finished loading the solution."
     (message "Server is not ready yet")))
 
 (defun omnisharp--check-ready-status-worker ()
-  (omnisharp-post-message-curl-as-json
-   (concat (omnisharp-get-host) "checkreadystatus")))
+  (let ((result (omnisharp-post-message-curl-as-json
+		 (concat (omnisharp-get-host) "checkreadystatus"))))
+    (eq result t)))
 
 ;;;###autoload
 (defun omnisharp-fix-code-issue-at-point ()


### PR DESCRIPTION
Fix these errors/warnings:

(emacs-version)
"GNU Emacs 24.3.91.1 (x86_64-apple-darwin, NS apple-appkit-1038.36)
 of 2014-05-12 on bob.porkrind.org"

In omnisharp-add-reference:
omnisharp.el:565:23:Error: `add-to-list' can't use lexical var`tmp-params';
    use `push' or`cl-pushnew'
In omnisharp--choose-quickfix-ido:
omnisharp.el:1713:1:Warning: Lexical argument shadows the dynamic variable t
omnisharp.el:1713:1:Warning: Unused lexical argument `omnisharp-navigate-to-solution-member'
omnisharp.el:1714:42:Error: Invalid lambda variable t
In omnisharp-navigate-to-region:
omnisharp.el:1759:8:Warning: function`omnisharp-navigate-to-region' defined
    multiple times in this file
omnisharp.el:1775:8:Warning: function omnisharp-navigate-to-region used to
    take 0-1 arguments, now takes 0
omnisharp.el:1775:8:Warning: function `omnisharp-navigate-to-region' defined
    multiple times in this file
In omnisharp-start-omnisharp-server:
omnisharp.el:1846:4:Warning: misplaced interactive spec:`(interactive "fStart
    OmniSharpServer.exe for solution: ")'
In end of data:
omnisharp.el:1943:1:Warning: the function `messge' is not known to be defined.
