### PR TITLE
Removing nils from buffer list, and using list instead of alist.

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -362,7 +362,7 @@ its only argument."
   (omnisharp-post-message-curl-as-json-async
    (concat (omnisharp-get-host) "findusages")
    request
-   (-lambda ((&alist 'QuickFixes quickfixes))
+   (-lambda ((&list 'QuickFixes quickfixes))
             (apply callback (list (omnisharp--vector-to-list quickfixes))))))
 
 (defun omnisharp--find-usages-show-response (quickfixes)
@@ -1273,7 +1273,7 @@ is a more sophisticated matching framework than what popup.el offers."
 (defun omnisharp--convert-auto-complete-json-to-popup-format
   (json-result-alist)
   (mapcar
-   (-lambda ((&alist 'DisplayText display-text
+   (-lambda ((&list 'DisplayText display-text
                      'CompletionText completion-text
                      'Description description))
             (popup-make-item display-text

--- a/src/omnisharp-utils.el
+++ b/src/omnisharp-utils.el
@@ -126,7 +126,7 @@ the OmniSharp server understands."
 
 (defun omnisharp--buffer-exists-for-file-name (file-name)
   (let ((all-open-buffers-list
-         (-map 'buffer-file-name (buffer-list))))
+         (-map 'buffer-file-name (-non-nil (buffer-list)))))
     (--any? (string-equal file-name it)
             all-open-buffers-list)))
 


### PR DESCRIPTION
I couldn't find a function called alist so replaced it with list in emacs 24.4.1 and had nil values in my buffer-list which caused errors.

I only cleaned up a couple of issues as I found them.
