### PR TITLE
Remove quotes from flycheck checkers

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -127,9 +127,9 @@ server backend."
   (omnisharp--start-omnisharp-server-for-solution-in-parent-directory)
 
   ;; These are selected automatically when flycheck is enabled
-  (--each '('csharp-omnisharp-curl
-            'csharp-omnisharp-curl-code-issues
-            'csharp-omnisharp-curl-semantic-errors)
+  (--each '(csharp-omnisharp-curl
+            csharp-omnisharp-curl-code-issues
+            csharp-omnisharp-curl-semantic-errors)
 
     (add-to-list 'flycheck-checkers it)))
 


### PR DESCRIPTION
Without this change Flycheck breaks in all my buffers, and i get this error message:

(wrong-type-argument symbolp (quote csharp-omnisharp-curl-semantic-errors))
