### PR TITLE
Follow redirects with curl on unix

### DIFF
--- a/src/omnisharp-utils.el
+++ b/src/omnisharp-utils.el
@@ -195,7 +195,7 @@ communicate with the API."
   `(:command
     ,omnisharp--curl-executable-path
     :arguments
-    ("--ipv4" "--silent" "-H" "Content-type: application/json"
+    ("-L" "--ipv4" "--silent" "-H" "Content-type: application/json"
      "--data"
      ,(json-encode params)
      ,url)))


### PR DESCRIPTION
With mono 3.10.0 & OmniSharpServer aae94d9c4846cc16c89303172a2e5a7f92cd46c3 using Nancy.0.23.2, I get a 301 redirect for http://localhost:2000/semanticerrors

Here's a sample from _omnisharp-debug_

```
2014-12-26T02:24:38-0600
omnisharp--json-read-from-string error: "<html>^M
<head><title>301 Moved Permanently</title></head>^M
<body bgcolor=\"white\">^M
<center><h1>301 Moved Permanently</h1></center>^M
<hr><center>nginx</center>^M
</body>^M
</html>^M
{\"Errors\":[]}"
```

Not sure if anyone else is experiencing this. At this point I can't be bothered looking more deeply to see what is causing OmniSharpServer to serve redirects, and I think this little fix couldn't hurt.
