### PR TITLE
Fix "curl" being the first argument sent to curl

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -917,7 +917,7 @@ type errors."
                                         ; flycheck-csharp-omnisharp-curl-executable if it
                                         ; is set
             (eval
-             (omnisharp--get-curl-command-executable-string-for-api-name
+             (omnisharp--get-curl-command-arguments-string-for-api-name
               (omnisharp--get-common-params)
               "syntaxerrors")))
 
@@ -939,7 +939,7 @@ type errors."
 then accept and have fixed automatically."
   :command ("curl"
             (eval
-             (omnisharp--get-curl-command-executable-string-for-api-name
+             (omnisharp--get-curl-command-arguments-string-for-api-name
               (omnisharp--get-common-params)
               "getcodeissues")))
 
@@ -959,7 +959,7 @@ then accept and have fixed automatically."
 compilation."
   :command ("curl"
             (eval
-             (omnisharp--get-curl-command-executable-string-for-api-name
+             (omnisharp--get-curl-command-arguments-string-for-api-name
               (omnisharp--get-common-params)
               "semanticerrors")))
 

--- a/src/omnisharp-utils.el
+++ b/src/omnisharp-utils.el
@@ -175,7 +175,7 @@ the curl program. Depends on the operating system."
                       single-or-multiline-log-string))
       (insert "\n"))))
 
-(defun omnisharp--get-curl-command-executable-string-for-api-name
+(defun omnisharp--get-curl-command-arguments-string-for-api-name
   (params api-name)
   "Returns the full command to call curl with PARAMS for the api API-NAME.
 Example: when called with \"getcodeactions\", returns
@@ -185,9 +185,7 @@ with \"stuff\" set to sensible values."
          (omnisharp--get-curl-command
           (concat (omnisharp-get-host) api-name)
           params)))
-    (cons
-     (plist-get command-plist :command)
-     (plist-get command-plist :arguments))))
+    (plist-get command-plist :arguments)))
 
 (defun omnisharp--get-curl-command-unix (url params)
   "Returns a command using plain curl that can be executed to


### PR DESCRIPTION
There's no need to have the command in the list returned by `omnisharp--get-curl-command-executable-string-for-api-name`.
