### PR TITLE
Autoload company backend

### DIFF
--- a/src/actions/omnisharp-auto-complete-actions.el
+++ b/src/actions/omnisharp-auto-complete-actions.el
@@ -247,6 +247,7 @@ triggers a completion immediately"
           symbol)
       'stop)))
 
+;;;###autoload
 (defun company-omnisharp (command &optional arg &rest ignored)
   "`company-mode' completion back-end using OmniSharp."
   (cl-case command


### PR DESCRIPTION
It seems to me the convention is to load company backends, at least from what I can tell with the bundled backends and at least one other backend (`company-tern`), so they can be added to `'company-backends` without loading the entire library.