### PR TITLE
Fix company-omnisharp when omnisharp isn't loaded yet

### DIFF
--- a/src/actions/omnisharp-auto-complete-actions.el
+++ b/src/actions/omnisharp-auto-complete-actions.el
@@ -251,7 +251,7 @@ triggers a completion immediately"
 (defun company-omnisharp (command &optional arg &rest ignored)
   "`company-mode' completion back-end using OmniSharp."
   (cl-case command
-    (prefix (and omnisharp-mode
+    (prefix (bound-and-true-p omnisharp-mode
                  (not (company-in-string-or-comment))
                  (omnisharp-company--prefix)))
 


### PR DESCRIPTION
This prevents `company-omnisharp` from throwing a variable is void error message when preemptively added to `company-backends` using autoload and `company-mode` is enabled in a non `omnisharp-mode` buffer.