### PR TITLE
Non-prefix matching

### DIFF
--- a/src/actions/omnisharp-auto-complete-actions.el
+++ b/src/actions/omnisharp-auto-complete-actions.el
@@ -263,19 +263,21 @@ triggers a completion immediately"
           symbol)
       'stop)))
 
-(defun omnisharp-company-flx-score-filter-list (query l cache)
+(defun omnisharp-company-flx-score-filter-list (query candidates cache)
   (let ((matches nil))
-    (dolist (elt l)
-      (let* ((completion-text (omnisharp--get-company-candidate-data elt 'CompletionText))
+    (dolist (candidate candidates)
+      (let* ((completion-text (omnisharp--get-company-candidate-data
+                               candidate
+                               'CompletionText))
              (flx-val (flx-score completion-text query cache)))
         (when (not (null flx-val))
-          (setq matches (cons (cons elt flx-val) matches)))))
+          (setq matches (cons (cons candidate flx-val) matches)))))
 
     (if omnisharp-company-match-sort-by-flx-score
         (setq matches (sort matches (lambda (el1 el2) (> (nth 1 el1) (nth 1 el2)))))
       (setq matches (reverse matches)))
     
-    (mapcar (lambda (el1) (car el1)) matches)))
+    (mapcar 'car matches)))
 
 (defvar omnisharp-company-current-flx-match-list nil)
 (defvar omnisharp-company-current-flx-arg-being-matched nil)
@@ -294,10 +296,11 @@ triggers a completion immediately"
       (setq omnisharp-company-match-type 'company-match-simple)))
 
   (cl-case command
-    (prefix (when (and (bound-and-true-p omnisharp-mode) (not (company-in-string-or-comment)))
+    (prefix (when (and (bound-and-true-p omnisharp-mode)
+                       (not (company-in-string-or-comment)))
               (omnisharp-company--prefix)))
 
-    (candidates (if (and (fboundp 'flx-score) (eq omnisharp-company-match-type 'company-match-flx))
+    (candidates (if (eq omnisharp-company-match-type 'company-match-flx)
                     ;;flx matching
                     (progn
                         ;; If the completion arg is empty, just return what the server sends
@@ -309,15 +312,16 @@ triggers a completion immediately"
                             (setq omnisharp-company-current-flx-match-list (omnisharp--get-company-candidates arg))
                             (setq omnisharp-company-current-flx-arg-being-matched arg))
 
-                          ;; Let flex sort the results
+                          ;; Let flex filter the results
                           (omnisharp-company-flx-score-filter-list arg
                                                                    omnisharp-company-current-flx-match-list
                                                                    omnisharp-company-flx-cache)))
                     (omnisharp--get-company-candidates arg)))
 
 
-    ;; because "" doesn't return everything
-    (no-cache (or (equal arg "") (not (eq omnisharp-company-match-type 'company-match-simple))))
+    ;; because "" doesn't return everything, and we don't cache if we're handling the filtering
+    (no-cache (or (equal arg "")
+                  (not (eq omnisharp-company-match-type 'company-match-simple))))
 
     (match (if (eq omnisharp-company-match-type 'company-match-simple)
                nil
@@ -338,10 +342,9 @@ triggers a completion immediately"
 
     (ignore-case omnisharp-company-ignore-case)
 
-    (sorted omnisharp-company-sort-results)
-    ;; (sorted (if (eq omnisharp-company-match-type 'company-match-simple)
-    ;;             (not omnisharp-company-sort-results)
-    ;;           t))
+    (sorted (if (eq omnisharp-company-match-type 'company-match-simple)
+                (not omnisharp-company-sort-results)
+              t))
 
     ;; Check to see if we need to do any templating
     (post-completion (setq omnisharp-company-current-flx-arg-being-matched nil)

--- a/src/actions/omnisharp-auto-complete-actions.el
+++ b/src/actions/omnisharp-auto-complete-actions.el
@@ -305,7 +305,7 @@ triggers a completion immediately"
     ;; because "" doesn't return everything
     (no-cache (or (equal arg "") (not (eq omnisharp-company-match-type 'company-match-simple))))
 
-    (match (if (eq omnisharp-company-do-server-matching 'company-match-simple)
+    (match (if (eq omnisharp-company-match-type 'company-match-simple)
                nil
              0))
 

--- a/src/actions/omnisharp-auto-complete-actions.el
+++ b/src/actions/omnisharp-auto-complete-actions.el
@@ -251,9 +251,9 @@ triggers a completion immediately"
 (defun company-omnisharp (command &optional arg &rest ignored)
   "`company-mode' completion back-end using OmniSharp."
   (cl-case command
-    (prefix (bound-and-true-p omnisharp-mode
-                 (not (company-in-string-or-comment))
-                 (omnisharp-company--prefix)))
+    (prefix (bound-and-true-p omnisharp-mode)
+            (not (company-in-string-or-comment))
+            (omnisharp-company--prefix))
 
     (candidates (omnisharp--get-company-candidates arg))
 


### PR DESCRIPTION
As requested by @nosami, company integration can now do non-prefix matching, leaving the server to do all the matching work.

There's also a fix in here; I haven't pulled in a while, but company integration just threw a macro expansion error whenever I tried to use it. 