### PR TITLE
Add command for providing and selecting implementations using popup

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -319,7 +319,7 @@ implementations found in omnisharp-find-implementations-popup."
   (let* ((current       (car items))
 	 (rest          (cdr items))
 	 (current-title (omnisharp-get-implementation-title current)))
-    (if (eq title current-title)
+    (if (equal title current-title)
 	current
       (omnisharp-get-implementation-by-name rest title))))
 

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -309,24 +309,15 @@ information about implementations found in omnisharp-find-implementations-popup.
        (number-to-string (cdr (assoc 'Line item))))
       )))
 
-(defun omnisharp-get-implementation-titles (items)
-  "Get a list of the human-readable class-name declaration from a list
-implementations found in omnisharp-find-implementations-popup."
-  (mapcar 'omnisharp-get-implementation-title items))
-
 (defun omnisharp-get-implementation-by-name (items title)
   "Return the implementation-object which matches the provided title."
-  (let* ((current       (car items))
-	 (rest          (cdr items))
-	 (current-title (omnisharp-get-implementation-title current)))
-    (if (equal title current-title)
-	current
-      (omnisharp-get-implementation-by-name rest title))))
+  (--first (string= title (omnisharp-get-implementation-title it))
+	   items))
 
 (defun omnisharp-navigate-to-implementations-popup (items)
   "Creates a navigate-to-implementation popup with the provided items
 and navigates to the selected one."
-  (let* ((chosen-title (popup-menu* (omnisharp-get-implementation-titles items)))
+  (let* ((chosen-title (popup-menu* (mapcar 'omnisharp-get-implementation-title items)))
 	 (chosen-item  (omnisharp-get-implementation-by-name items chosen-title)))
     (omnisharp-go-to-file-line-and-column chosen-item)))
 

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -297,9 +297,17 @@ to select one (or more) to jump to."
 	    (omnisharp-navigate-to-implementations-popup quickfixes))))))
 
 (defun omnisharp-get-implementation-title (item)
-  "Get the human-readable class-name declaration from a list with
+  "Get the human-readable class-name declaration from an alist with
 information about implementations found in omnisharp-find-implementations-popup."
-  (cdr (car item)))
+  (let* ((text (cdr (assoc 'Text item))))
+    (if (or (string-match-p " class " text)
+	      (string-match-p " interface " text))
+	text
+      (concat
+       (file-name-nondirectory (cdr (assoc 'FileName item)))
+       ":"
+       (number-to-string (cdr (assoc 'Line item))))
+      )))
 
 (defun omnisharp-get-implementation-titles (items)
   "Get a list of the human-readable class-name declaration from a list


### PR DESCRIPTION
This is much more keyboard-friendly and instant (and ReSharper-like) than providing the results in a separate buffer.