### PR TITLE
Bypass proxy for localhost URLs

### DIFF
--- a/src/omnisharp-utils.el
+++ b/src/omnisharp-utils.el
@@ -212,7 +212,8 @@ api at URL using that file as the parameters."
                  )))
     `(:command ,omnisharp--curl-executable-path
                :arguments
-               ("--silent" "-H" "Content-type: application/json"
+               ("--noproxy" "localhost"
+                "--silent" "-H" "Content-type: application/json"
                 "--data-binary"
                 ;; @ specifies a file path to curl
                 ,path-with-curl-prefix


### PR DESCRIPTION
Hi Mika,

This PR explicitly by pass any proxy for localhost URLs in `omnisharp--get-curl-command-windows-with-tmp-file`. It fixes my communication errors on my Windows work box.

Cheers,
syl20bnr