### PR TITLE
Don`t add "mono" to server executable path if using omnisharp-roslyn shell script in UNIX.

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -27,6 +27,7 @@
 (require 'popup)
 (require 'etags)
 (require 'flycheck)
+(require 's)
 
 (add-to-list 'load-path (expand-file-name (concat (file-name-directory (or load-file-name buffer-file-name)) "/src/")))
 (add-to-list 'load-path (expand-file-name (concat (file-name-directory (or load-file-name buffer-file-name)) "/src/actions")))
@@ -1078,18 +1079,12 @@ cursor at that location"
         imenu-list)
     (error nil)))
 
-;; http://xahlee.blogspot.ru/2011/09/emacs-lisp-function-to-trim-string.html
-(defun trim-string (string)
-   "Remove white spaces in beginning and ending of STRING.
-           White space here is any of: space, tab, emacs newline (line feed, ASCII 10)."
-   (replace-regexp-in-string "\\`[ \t\n]*" "" (replace-regexp-in-string "[ \t\n]*\\'" "" string)))
-
 (defun omnisharp-format-usage-output-to-ido (item)
   (let ((filename (cdr (assoc 'FileName item))))
      (cons
       (cons
        (car (car item))
-       (concat (car (last (split-string filename "/"))) ": " (trim-string (cdr (car item)))))
+       (concat (car (last (split-string filename "/"))) ": " (s-trim (cdr (car item)))))
       (cdr item))))
 
 (defun omnisharp-navigate-to-implementation (&optional other-window)

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -1079,7 +1079,7 @@ cursor at that location"
         imenu-list)
     (error nil)))
 
-(defun omnisharp-format-usage-output-to-ido (item)
+(defun omnisharp-format-find-output-to-ido (item)
   (let ((filename (cdr (assoc 'FileName item))))
      (cons
       (cons
@@ -1098,7 +1098,9 @@ cursor at that location"
              ((equal 1 (length quickfixes))
               (omnisharp-go-to-file-line-and-column (car quickfixes) other-window))
              (t
-              (omnisharp--choose-and-go-to-quickfix-ido quickfixes other-window)))))
+              (omnisharp--choose-and-go-to-quickfix-ido
+               (mapcar 'omnisharp-format-find-output-to-ido quickfixes)
+               other-window)))))
 
 (defun omnisharp-navigate-to-usage (&optional other-window)
    (interactive "P")
@@ -1112,7 +1114,7 @@ cursor at that location"
             (omnisharp-go-to-file-line-and-column (car quickfixes) other-window))
            (t
             (omnisharp--choose-and-go-to-quickfix-ido
-             (mapcar 'omnisharp-format-usage-output-to-ido quickfixes)
+             (mapcar 'omnisharp-format-find-output-to-ido quickfixes)
              other-window)))))
 
 (defun omnisharp-navigate-to-current-file-member

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -1078,21 +1078,32 @@ cursor at that location"
         imenu-list)
     (error nil)))
 
-
 ;; http://xahlee.blogspot.ru/2011/09/emacs-lisp-function-to-trim-string.html
 (defun trim-string (string)
    "Remove white spaces in beginning and ending of STRING.
            White space here is any of: space, tab, emacs newline (line feed, ASCII 10)."
    (replace-regexp-in-string "\\`[ \t\n]*" "" (replace-regexp-in-string "[ \t\n]*\\'" "" string)))
 
-(defun omnisharp-format-usage-output-to-ido
-     (item)
-   (let ((filename (cdr (assoc 'FileName item))))
+(defun omnisharp-format-usage-output-to-ido (item)
+  (let ((filename (cdr (assoc 'FileName item))))
      (cons
       (cons
        (car (car item))
        (concat (car (last (split-string filename "/"))) ": " (trim-string (cdr (car item)))))
       (cdr item))))
+
+(defun omnisharp-navigate-to-implementation (&optional other-window)
+  (interactive "P")
+  (let ((quickfixes (omnisharp--vector-to-list
+                     (cdr (assoc 'QuickFixes (omnisharp-post-message-curl-as-json
+                                              (concat (omnisharp-get-host) "findimplementations")
+                                              (omnisharp--get-common-params)))))))
+       (cond ((equal 0 (length quickfixes))
+              (message "No implementations found."))
+             ((equal 1 (length quickfixes))
+              (omnisharp-go-to-file-line-and-column (car quickfixes) other-window))
+             (t
+              (omnisharp--choose-and-go-to-quickfix-ido quickfixes other-window)))))
 
 (defun omnisharp-navigate-to-usage (&optional other-window)
    (interactive "P")
@@ -1472,7 +1483,6 @@ contents with the issue at point fixed."
                          'face 'helm-grep-file)
              (nth 0 (split-string (cdr (assoc 'Text candidate)) "(")))
      candidate)))
-
 
 (provide 'omnisharp)
 

--- a/src/omnisharp-utils.el
+++ b/src/omnisharp-utils.el
@@ -285,8 +285,9 @@ moving point."
 		     "-s"
 		     solution-file-path-arg)))
     (cond
-     ((or (equal system-type 'cygwin) ;; No mono needed on cygwin
-	  (equal system-type 'windows-nt))
+     ((or (equal system-type 'cygwin) ;; No mono needed on cygwin or if using omnisharp-roslyn
+          (equal system-type 'windows-nt)
+          (not (s-ends-with? ".exe" server-exe-file-path-arg)))
       args)
      (t ; some kind of unix: linux or osx
       (cons "mono" args)))))


### PR DESCRIPTION
In omnisharp-roslyn "scripts/Omnisharp" already runs mono, so we don`t need to add it to executable path.