### PR TITLE
Uplift Travis build to emacs 24.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall
   | sh && source ~/.dnx/dnvm/dnvm.sh && dnvm upgrade
 
 before_script:
-    - curl -fsSkL https://gist.github.com/rejeep/7736123/raw > travis.sh && source ./travis.sh
+    - curl -fsSkL https://gist.github.com/ianbattersby/c3399aa8cd9e2a6f8afa/raw > travis.sh && source ./travis.sh
     - evm list
     - emacs --version
     - cask install


### PR DESCRIPTION
Given the use of `nadvice` in the `incremental-updates` branch it's now necessary to move the Travis build to 24.4 where this package is included. 