### PR TITLE
[wip] Pass -c Cygwin to server when running on cygwin.

### DIFF
--- a/src/omnisharp-utils.el
+++ b/src/omnisharp-utils.el
@@ -283,7 +283,8 @@ moving point."
 	 (solution-file-path-arg (expand-file-name solution-file-path))
 	 (args (list server-exe-file-path-arg
 		     "-s"
-		     solution-file-path-arg)))
+		     solution-file-path-arg
+		     (if (equal system-type 'cygwin) "-c Cygwin" ""))))
     (cond
      ((or (equal system-type 'cygwin) ;; No mono needed on cygwin or if using omnisharp-roslyn
           (equal system-type 'windows-nt)


### PR DESCRIPTION
Launching OmniSharpServer with `-c Cygwin` allows all cygwin paths to be translated properly without having to mess around in config.json when running on cygwin.

Marked WIP because it should probably be conditionally appending to the list instead of this abomination. (TODO)

I just wanted to check if this makes sense before learning elisp and cleaning it up.

Cheers
