### PR TITLE
[Roslyn] Fixed findsymbols request

### DIFF
--- a/src/omnisharp-helm-integration.el
+++ b/src/omnisharp-helm-integration.el
@@ -56,7 +56,7 @@
     (let (candidates)
       (omnisharp--send-command-to-server-sync
        "findsymbols"
-       nil
+       '((Filter . ""))
        (-lambda ((&alist 'QuickFixes quickfixes))
                 (setq candidates
                       (-map 'omnisharp--helm-find-symbols-transform-candidate


### PR DESCRIPTION
The request Filter property must now be passed in otherwise an NRE (NullReferenceException) is thrown.

All symbols for the current project are now returned as before.