### PR TITLE
[Roslyn] Add support for http request

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -34,6 +34,7 @@
 
 (require 'omnisharp-server-management)
 (require 'omnisharp-utils)
+(require 'omnisharp-http-utils)
 (require 'omnisharp-server-actions)
 (require 'omnisharp-auto-complete-actions)
 (require 'omnisharp-current-symbol-actions)

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -457,7 +457,7 @@ cursor at that location"
 (defun omnisharp--eldoc-worker ()
   "Gets type information from omnisharp server about the symbol at point"
   (omnisharp--completion-result-get-item 
-   (omnisharp-post-message-curl-as-json
+   (omnisharp-post-http-message
     (concat (omnisharp-get-host) "typelookup")
     (omnisharp--get-request-object))
    'Type))

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -458,7 +458,7 @@ cursor at that location"
   "Gets type information from omnisharp server about the symbol at point"
   (omnisharp--completion-result-get-item 
    (omnisharp-post-http-message
-    (concat (omnisharp-get-host) "typelookup")
+    (concat (omnisharp--get-host) "typelookup")
     (omnisharp--get-request-object))
    'Type))
 

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -9,32 +9,34 @@
   (concat (omnisharp--get-host) api-name))
 
 ;;;###autoload
-(defun omnisharp-post-http-message (url &optional params)
+(defun omnisharp-post-http-message (url callback &optional params async)
   "Post http request to server. Return result."
-  (let* ((url (omnisharp--get-api-url url))
-         (response (omnisharp--submit-request url params))
-         (data (elt response 3)))
-    (unless data
-      (message "Error when sending request %s" url))
-    (when omnisharp-debug
-      (message "Response:\n%s" (prin1-to-string data)))
-    data))
+  (omnisharp--submit-request (omnisharp--get-api-url url) callback params async))
 
-(defun omnisharp--submit-request (url &optional params)
+(defun omnisharp--submit-request (url callback &optional params async)
   (if (require 'request nil 'noerror)
-      (request url
-               :type "POST"
-               :parser 'json-read
-               :sync t
-               :data (json-encode params)
-               :error
-               (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
-                              (message "Error from %s : %S" url error-thrown)))
-               :complete (lambda (&rest _) (when omnisharp-debug (message "Request completed")))
-               :success (cl-function
-                         (lambda (&key data &allow-other-keys) (when omnisharp-debug (message "Request succeeded"))
-                           )))
-    (message "ERROR: You must install 'request-deferred' package")
-    ))
+      (lexical-let* ((c callback))
+        (request url
+                 :type "POST"
+                 :parser 'json-read
+                 :sync (not async)
+                 :data (json-encode params)
+                 :error (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
+                                       (message "Error from %s : %S" url error-thrown)))
+                 :complete
+                 (lambda (&rest _)
+                   (when omnisharp-debug
+                     (message "Request completed")))
+                 :success (cl-function (lambda (&key data &allow-other-keys)
+                                         (progn
+                                           (when c
+                                             (funcall c data))
+                                           (when omnisharp-debug
+                                             (message "Request succeeded"))
+                                           )))
+                 :status-code '((404 . (lambda (&rest _) (message (format "Endpoint %s does not exist." url))))
+                                (500 . (lambda (&rest _) (message (format "Error from  %s." url))))
+                                )))
+    (message "ERROR: You must install 'request-deferred' package")))
 
 (provide 'omnisharp-http-utils)

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -3,7 +3,7 @@
   "Post json stuff to url with --data set to given params. Return
 result."
   (let ((curl-command-plist
-         (omnisharp--get-curl-command url params)))
+         (omnisharp--get-curl-command (omnisharp--get-api-url url) params)))
     (with-temp-buffer
       (apply 'call-process
              (plist-get curl-command-plist :command)
@@ -80,7 +80,7 @@ api at URL using that file as the parameters."
 
 (defun omnisharp-post-message-curl-as-json (url &optional params)
   (omnisharp--json-read-from-string
-   (omnisharp-post-message-curl (concat (omnisharp-get-host) url) params)))
+   (omnisharp-post-message-curl url params)))
 
 
 (defun omnisharp--server-process-sentinel (process event)

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -29,7 +29,7 @@
                :data (json-encode params)
                :error
                (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
-                              (message "Got error: %S" error-thrown)))
+                              (message "Error from %s : %S" url error-thrown)))
                :complete (lambda (&rest _) (when omnisharp-debug (message "Request completed")))
                :success (cl-function
                          (lambda (&key data &allow-other-keys) (when omnisharp-debug (message "Request succeeded"))

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -37,8 +37,4 @@
     (message "ERROR: You must install 'request-deferred' package")
     ))
 
-(defun omnisharp--server-process-sentinel (process event)
-  (if (string-match "^exited abnormally" event)
-      (error (concat "OmniSharp server process " event))))
-
 (provide 'omnisharp-http-utils)

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -21,19 +21,21 @@
     data))
 
 (defun omnisharp--submit-request (url &optional params)
-  (require 'request)
-  (request url
-           :type "POST"
-           :parser 'json-read
-           :sync t
-           :data (json-encode params)
-           :error
-           (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
-                          (message "Got error: %S" error-thrown)))
-           :complete (lambda (&rest _) (when omnisharp-debug (message "Request completed")))
-           :success (cl-function
-                     (lambda (&key data &allow-other-keys) (when omnisharp-debug (message "Request succeeded"))
-                       ))))
+  (if (require 'request nil 'noerror)
+      (request url
+               :type "POST"
+               :parser 'json-read
+               :sync t
+               :data (json-encode params)
+               :error
+               (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
+                              (message "Got error: %S" error-thrown)))
+               :complete (lambda (&rest _) (when omnisharp-debug (message "Request completed")))
+               :success (cl-function
+                         (lambda (&key data &allow-other-keys) (when omnisharp-debug (message "Request succeeded"))
+                           )))
+    (message "ERROR: You must install 'request-deferred' package")
+    ))
 
 (defun omnisharp--server-process-sentinel (process event)
   (if (string-match "^exited abnormally" event)

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -1,12 +1,12 @@
 
-(defun omnisharp-get-host ()
+(defun omnisharp--get-host ()
   "Makes sure omnisharp-host is ended by / "
   (if (string= (substring omnisharp-host -1 ) "/")
       omnisharp-host
     (concat omnisharp-host "/")))
 
 (defun omnisharp--get-api-url (api-name)
-  (concat (omnisharp-get-host) api-name))
+  (concat (omnisharp--get-host) api-name))
 
 ;;;###autoload
 (defun omnisharp-post-http-message (url &optional params)

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -1,138 +1,4 @@
 
-(defun omnisharp-get-host ()
-  "Makes sure omnisharp-host is ended by / "
-  (if (string= (substring omnisharp-host -1 ) "/")
-      omnisharp-host
-    (concat omnisharp-host "/")))
-
-(defun omnisharp--get-api-url (api-name)
-  (concat (omnisharp-get-host) api-name))
-
-(defun omnisharp--write-quickfixes-to-compilation-buffer
-  (quickfixes
-   buffer-name
-   buffer-header
-   &optional dont-save-old-pos)
-  "Takes a list of QuickFix objects and writes them to the
-compilation buffer with HEADER as its header. Shows the buffer
-when finished.
-
-If DONT-SAVE-OLD-POS is specified, will not save current position to
-find-tag-marker-ring. This is so this function may be used without
-messing with the ring."
-  (let ((output-in-compilation-mode-format
-         (mapcar
-          'omnisharp--find-usages-output-to-compilation-output
-          quickfixes)))
-
-    (omnisharp--write-lines-to-compilation-buffer
-     output-in-compilation-mode-format
-     (get-buffer-create buffer-name)
-     buffer-header)
-    (unless dont-save-old-pos
-      (ring-insert find-tag-marker-ring (point-marker))
-      (omnisharp--show-last-buffer-position-saved-message
-       (buffer-file-name)))))
-
-(defun omnisharp--write-lines-to-compilation-buffer
-  (lines-to-write buffer-to-write-to &optional header)
-  "Writes the given lines to the given buffer, and sets
-compilation-mode on. The contents of the buffer are erased. The
-buffer is marked read-only after inserting all lines.
-
-LINES-TO-WRITE are the lines to write, as-is.
-
-If HEADER is given, that is written to the top of the buffer.
-
-Expects the lines to be in a format that compilation-mode
-recognizes, so that the user may jump to the results."
-  (with-current-buffer buffer-to-write-to
-    (let ((inhibit-read-only t))
-      ;; read-only-mode new in Emacs 24.3
-      (if (fboundp 'read-only-mode)
-          (read-only-mode nil)
-        (setq buffer-read-only nil))
-      (erase-buffer)
-
-      (when (not (null header))
-        (insert header))
-
-      (mapc (lambda (element)
-              (insert element)
-              (insert "\n"))
-            lines-to-write)
-      (compilation-mode)
-      (if (fboundp 'read-only-mode)
-          (read-only-mode t)
-        (setq buffer-read-only t))
-      (display-buffer buffer-to-write-to))))
-
-(defun omnisharp--find-usages-output-to-compilation-output
-  (json-result-single-element)
-  "Converts a single element of a /findusages JSON response to a
-format that the compilation major mode understands and lets the user
-follow results to the locations in the actual files."
-  (let ((filename (cdr (assoc 'FileName json-result-single-element)))
-        (text (cdr (assoc 'Text json-result-single-element)))
-        (line (cdr (assoc 'Line json-result-single-element)))
-        (column (cdr (assoc 'Column json-result-single-element)))
-        (text (cdr (assoc 'Text json-result-single-element))))
-    (concat filename
-            ":"
-            (prin1-to-string line)
-            ":"
-            (prin1-to-string column)
-            ": \n"
-            text
-            "\n")))
-
-(defun omnisharp--set-buffer-contents-to (filename-for-buffer
-                                          new-buffer-contents
-                                          &optional
-                                          result-point-line
-                                          result-point-column)
-  "Sets the buffer contents to new-buffer-contents for the buffer
-visiting filename-for-buffer. If no buffer is visiting that file, does
-nothing. Afterwards moves point to the coordinates RESULT-POINT-LINE
-and RESULT-POINT-COLUMN.
-
-If RESULT-POINT-LINE and RESULT-POINT-COLUMN are not given, and a
-buffer exists for FILENAME-FOR-BUFFER, its current positions are
-used. If a buffer does not exist, the file is visited and the default
-point position is used."
-  (omnisharp--find-file-possibly-in-other-window
-   filename-for-buffer nil) ; not in other-window
-
-  ;; Default values are the ones in the buffer that is visiting
-  ;; filename-for-buffer.
-  (setq result-point-line
-        (or result-point-line (line-number-at-pos)))
-  (setq result-point-column
-        (or result-point-column (omnisharp--current-column)))
-
-  (save-buffer)
-  (erase-buffer)
-  (insert new-buffer-contents)
-
-  ;; Hack. Puts point where it belongs.
-  (omnisharp-go-to-file-line-and-column-worker
-   result-point-line result-point-column filename-for-buffer))
-
-(defun omnisharp--current-column ()
-  "Returns the current column, converting tab characters in a way that
-the OmniSharp server understands."
-  (let ((tab-width 1))
-    (current-column)))
-
-(defun omnisharp--buffer-exists-for-file-name (file-name)
-  (let ((all-open-buffers-list
-         (-map 'buffer-file-name (-non-nil (buffer-list)))))
-    (--any? (string-equal file-name it)
-            all-open-buffers-list)))
-
-(defun omnisharp--get-current-buffer-contents ()
-  (buffer-substring-no-properties (buffer-end 0) (buffer-end 1)))
-
 (defun omnisharp-post-message-curl (url &optional params)
   "Post json stuff to url with --data set to given params. Return
 result."
@@ -161,19 +27,6 @@ the curl program. Depends on the operating system."
 
 (defun omnisharp--log-curl-command (curl-command)
   (omnisharp--log (prin1-to-string curl-command)))
-
-(defun omnisharp--log (single-or-multiline-log-string)
-  (let* ((log-buffer (get-buffer-create "*omnisharp-debug*"))
-         (iso-format-string "%Y-%m-%dT%T%z")
-         (timestamp-and-log-string
-          (format-time-string iso-format-string (current-time))))
-    (with-current-buffer log-buffer
-      (end-of-buffer)
-      (insert "\n\n\n")
-      (insert (concat timestamp-and-log-string
-                      "\n"
-                      single-or-multiline-log-string))
-      (insert "\n"))))
 
 (defun omnisharp--get-curl-command-arguments-string-for-api-name
   (params api-name)
@@ -225,72 +78,14 @@ api at URL using that file as the parameters."
   (with-temp-file target-path
     (insert stuff-to-write-to-file)))
 
-(defun omnisharp--json-read-from-string (json-string
-                                         &optional error-message)
-  "Deserialize the given JSON-STRING to a lisp object. If
-something goes wrong, return a human-readable warning."
-  (condition-case nil
-      (json-read-from-string json-string)
-    (error
-     (when omnisharp-debug
-       (omnisharp--log (concat "omnisharp--json-read-from-string error: "
-                               (prin1-to-string json-string))))
-     (or error-message
-         "Error communicating to the OmniSharpServer instance"))))
-
 (defun omnisharp-post-message-curl-as-json (url &optional params)
   (omnisharp--json-read-from-string
    (omnisharp-post-message-curl (concat (omnisharp-get-host) url) params)))
 
-(defun omnisharp--replace-symbol-in-buffer-with (symbol-to-replace
-                                                 replacement-string)
-  "In the current buffer, replaces the given SYMBOL-TO-REPLACE
-\(a string\) with REPLACEMENT-STRING."
-  (search-backward symbol-to-replace)
-  (replace-match replacement-string t t))
-
-(defun omnisharp--insert-namespace-import (full-import-text-to-insert)
-  "Inserts the given text at the top of the current file without
-moving point."
-  (save-excursion
-    (beginning-of-buffer)
-    (insert "using " full-import-text-to-insert ";")
-    (newline)))
-
-(defun omnisharp--current-word-or-empty-string ()
-  (or (thing-at-point 'symbol)
-      ""))
-
-(defun omnisharp--t-or-json-false (val)
-  (if val
-      t
-    :json-false))
 
 (defun omnisharp--server-process-sentinel (process event)
   (if (string-match "^exited abnormally" event)
       (error (concat "OmniSharp server process " event))))
-
-(defun omnisharp--valid-solution-path-p (path-to-solution)
-  (or (string= (file-name-extension path-to-solution) "sln")
-      (file-directory-p path-to-solution)))
-
-(defun omnisharp--get-omnisharp-server-executable-command
-  (solution-file-path &optional server-exe-file-path)
-  (let* ((server-exe-file-path-arg (expand-file-name 
-				    (if (eq nil server-exe-file-path)
-					omnisharp-server-executable-path
-				      server-exe-file-path)))
-	 (solution-file-path-arg (expand-file-name solution-file-path))
-	 (args (list server-exe-file-path-arg
-		     "-s"
-		     solution-file-path-arg)))
-    (cond
-     ((or (equal system-type 'cygwin) ;; No mono needed on cygwin or if using omnisharp-roslyn
-          (equal system-type 'windows-nt)
-          (not (s-ends-with? ".exe" server-exe-file-path-arg)))
-      args)
-     (t ; some kind of unix: linux or osx
-      (cons "mono" args)))))
 
 
 (defun omnisharp-post-message-curl-as-json-async (url params callback)
@@ -323,6 +118,5 @@ Returns the curl process"
                            (kill-buffer process-buffer)
                            output))))))
     process))
-
 
 (provide 'omnisharp-http-utils)

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -1,0 +1,328 @@
+
+(defun omnisharp-get-host ()
+  "Makes sure omnisharp-host is ended by / "
+  (if (string= (substring omnisharp-host -1 ) "/")
+      omnisharp-host
+    (concat omnisharp-host "/")))
+
+(defun omnisharp--get-api-url (api-name)
+  (concat (omnisharp-get-host) api-name))
+
+(defun omnisharp--write-quickfixes-to-compilation-buffer
+  (quickfixes
+   buffer-name
+   buffer-header
+   &optional dont-save-old-pos)
+  "Takes a list of QuickFix objects and writes them to the
+compilation buffer with HEADER as its header. Shows the buffer
+when finished.
+
+If DONT-SAVE-OLD-POS is specified, will not save current position to
+find-tag-marker-ring. This is so this function may be used without
+messing with the ring."
+  (let ((output-in-compilation-mode-format
+         (mapcar
+          'omnisharp--find-usages-output-to-compilation-output
+          quickfixes)))
+
+    (omnisharp--write-lines-to-compilation-buffer
+     output-in-compilation-mode-format
+     (get-buffer-create buffer-name)
+     buffer-header)
+    (unless dont-save-old-pos
+      (ring-insert find-tag-marker-ring (point-marker))
+      (omnisharp--show-last-buffer-position-saved-message
+       (buffer-file-name)))))
+
+(defun omnisharp--write-lines-to-compilation-buffer
+  (lines-to-write buffer-to-write-to &optional header)
+  "Writes the given lines to the given buffer, and sets
+compilation-mode on. The contents of the buffer are erased. The
+buffer is marked read-only after inserting all lines.
+
+LINES-TO-WRITE are the lines to write, as-is.
+
+If HEADER is given, that is written to the top of the buffer.
+
+Expects the lines to be in a format that compilation-mode
+recognizes, so that the user may jump to the results."
+  (with-current-buffer buffer-to-write-to
+    (let ((inhibit-read-only t))
+      ;; read-only-mode new in Emacs 24.3
+      (if (fboundp 'read-only-mode)
+          (read-only-mode nil)
+        (setq buffer-read-only nil))
+      (erase-buffer)
+
+      (when (not (null header))
+        (insert header))
+
+      (mapc (lambda (element)
+              (insert element)
+              (insert "\n"))
+            lines-to-write)
+      (compilation-mode)
+      (if (fboundp 'read-only-mode)
+          (read-only-mode t)
+        (setq buffer-read-only t))
+      (display-buffer buffer-to-write-to))))
+
+(defun omnisharp--find-usages-output-to-compilation-output
+  (json-result-single-element)
+  "Converts a single element of a /findusages JSON response to a
+format that the compilation major mode understands and lets the user
+follow results to the locations in the actual files."
+  (let ((filename (cdr (assoc 'FileName json-result-single-element)))
+        (text (cdr (assoc 'Text json-result-single-element)))
+        (line (cdr (assoc 'Line json-result-single-element)))
+        (column (cdr (assoc 'Column json-result-single-element)))
+        (text (cdr (assoc 'Text json-result-single-element))))
+    (concat filename
+            ":"
+            (prin1-to-string line)
+            ":"
+            (prin1-to-string column)
+            ": \n"
+            text
+            "\n")))
+
+(defun omnisharp--set-buffer-contents-to (filename-for-buffer
+                                          new-buffer-contents
+                                          &optional
+                                          result-point-line
+                                          result-point-column)
+  "Sets the buffer contents to new-buffer-contents for the buffer
+visiting filename-for-buffer. If no buffer is visiting that file, does
+nothing. Afterwards moves point to the coordinates RESULT-POINT-LINE
+and RESULT-POINT-COLUMN.
+
+If RESULT-POINT-LINE and RESULT-POINT-COLUMN are not given, and a
+buffer exists for FILENAME-FOR-BUFFER, its current positions are
+used. If a buffer does not exist, the file is visited and the default
+point position is used."
+  (omnisharp--find-file-possibly-in-other-window
+   filename-for-buffer nil) ; not in other-window
+
+  ;; Default values are the ones in the buffer that is visiting
+  ;; filename-for-buffer.
+  (setq result-point-line
+        (or result-point-line (line-number-at-pos)))
+  (setq result-point-column
+        (or result-point-column (omnisharp--current-column)))
+
+  (save-buffer)
+  (erase-buffer)
+  (insert new-buffer-contents)
+
+  ;; Hack. Puts point where it belongs.
+  (omnisharp-go-to-file-line-and-column-worker
+   result-point-line result-point-column filename-for-buffer))
+
+(defun omnisharp--current-column ()
+  "Returns the current column, converting tab characters in a way that
+the OmniSharp server understands."
+  (let ((tab-width 1))
+    (current-column)))
+
+(defun omnisharp--buffer-exists-for-file-name (file-name)
+  (let ((all-open-buffers-list
+         (-map 'buffer-file-name (-non-nil (buffer-list)))))
+    (--any? (string-equal file-name it)
+            all-open-buffers-list)))
+
+(defun omnisharp--get-current-buffer-contents ()
+  (buffer-substring-no-properties (buffer-end 0) (buffer-end 1)))
+
+(defun omnisharp-post-message-curl (url &optional params)
+  "Post json stuff to url with --data set to given params. Return
+result."
+  (let ((curl-command-plist
+         (omnisharp--get-curl-command url params)))
+    (with-temp-buffer
+      (apply 'call-process
+             (plist-get curl-command-plist :command)
+             nil ;; infile
+             (buffer-name);; destination
+             nil ;; display (no specialities needed)
+             ;; these are just args
+             (plist-get curl-command-plist :arguments))
+      (buffer-string))))
+
+(defun omnisharp--get-curl-command (url params)
+  "Returns a command that may be used to communicate with the API via
+the curl program. Depends on the operating system."
+  (let ((curl-command
+         (if (equal system-type 'windows-nt)
+             (omnisharp--get-curl-command-windows-with-tmp-file url params)
+           (omnisharp--get-curl-command-unix url params))))
+    (when omnisharp-debug
+      (omnisharp--log-curl-command curl-command))
+    curl-command))
+
+(defun omnisharp--log-curl-command (curl-command)
+  (omnisharp--log (prin1-to-string curl-command)))
+
+(defun omnisharp--log (single-or-multiline-log-string)
+  (let* ((log-buffer (get-buffer-create "*omnisharp-debug*"))
+         (iso-format-string "%Y-%m-%dT%T%z")
+         (timestamp-and-log-string
+          (format-time-string iso-format-string (current-time))))
+    (with-current-buffer log-buffer
+      (end-of-buffer)
+      (insert "\n\n\n")
+      (insert (concat timestamp-and-log-string
+                      "\n"
+                      single-or-multiline-log-string))
+      (insert "\n"))))
+
+(defun omnisharp--get-curl-command-arguments-string-for-api-name
+  (params api-name)
+  "Returns the full command to call curl with PARAMS for the api API-NAME.
+Example: when called with \"getcodeactions\", returns
+\"curl (stuff) http://localhost:2000/getcodeactions (stuff)\"
+with \"stuff\" set to sensible values."
+  (let ((command-plist
+         (omnisharp--get-curl-command
+          (concat (omnisharp-get-host) api-name)
+          params)))
+    (plist-get command-plist :arguments)))
+
+(defun omnisharp--get-curl-command-unix (url params)
+  "Returns a command using plain curl that can be executed to
+communicate with the API."
+  `(:command
+    ,omnisharp--curl-executable-path
+    :arguments
+    ("--ipv4" "--silent" "-H" "Content-type: application/json"
+     "--data"
+     ,(json-encode params)
+     ,url)))
+
+(defun omnisharp--get-curl-command-windows-with-tmp-file (url params)
+  "Basically: put PARAMS to file, then create a curl command to the
+api at URL using that file as the parameters."
+  ;; TODO could optimise: short buffers need not be written to tmp
+  ;; files.
+  (omnisharp--write-json-params-to-tmp-file
+   omnisharp--windows-curl-tmp-file-path
+   (json-encode params))
+  (let ((path-with-curl-prefix
+         (concat "@"
+                 omnisharp--windows-curl-tmp-file-path
+                 )))
+    `(:command ,omnisharp--curl-executable-path
+               :arguments
+               ("--noproxy" "localhost"
+                "--silent" "-H" "Content-type: application/json"
+                "--data-binary"
+                ;; @ specifies a file path to curl
+                ,path-with-curl-prefix
+                ,url))))
+
+(defun omnisharp--write-json-params-to-tmp-file
+  (target-path stuff-to-write-to-file)
+  "Deletes the file when done."
+  (with-temp-file target-path
+    (insert stuff-to-write-to-file)))
+
+(defun omnisharp--json-read-from-string (json-string
+                                         &optional error-message)
+  "Deserialize the given JSON-STRING to a lisp object. If
+something goes wrong, return a human-readable warning."
+  (condition-case nil
+      (json-read-from-string json-string)
+    (error
+     (when omnisharp-debug
+       (omnisharp--log (concat "omnisharp--json-read-from-string error: "
+                               (prin1-to-string json-string))))
+     (or error-message
+         "Error communicating to the OmniSharpServer instance"))))
+
+(defun omnisharp-post-message-curl-as-json (url &optional params)
+  (omnisharp--json-read-from-string
+   (omnisharp-post-message-curl (concat (omnisharp-get-host) url) params)))
+
+(defun omnisharp--replace-symbol-in-buffer-with (symbol-to-replace
+                                                 replacement-string)
+  "In the current buffer, replaces the given SYMBOL-TO-REPLACE
+\(a string\) with REPLACEMENT-STRING."
+  (search-backward symbol-to-replace)
+  (replace-match replacement-string t t))
+
+(defun omnisharp--insert-namespace-import (full-import-text-to-insert)
+  "Inserts the given text at the top of the current file without
+moving point."
+  (save-excursion
+    (beginning-of-buffer)
+    (insert "using " full-import-text-to-insert ";")
+    (newline)))
+
+(defun omnisharp--current-word-or-empty-string ()
+  (or (thing-at-point 'symbol)
+      ""))
+
+(defun omnisharp--t-or-json-false (val)
+  (if val
+      t
+    :json-false))
+
+(defun omnisharp--server-process-sentinel (process event)
+  (if (string-match "^exited abnormally" event)
+      (error (concat "OmniSharp server process " event))))
+
+(defun omnisharp--valid-solution-path-p (path-to-solution)
+  (or (string= (file-name-extension path-to-solution) "sln")
+      (file-directory-p path-to-solution)))
+
+(defun omnisharp--get-omnisharp-server-executable-command
+  (solution-file-path &optional server-exe-file-path)
+  (let* ((server-exe-file-path-arg (expand-file-name 
+				    (if (eq nil server-exe-file-path)
+					omnisharp-server-executable-path
+				      server-exe-file-path)))
+	 (solution-file-path-arg (expand-file-name solution-file-path))
+	 (args (list server-exe-file-path-arg
+		     "-s"
+		     solution-file-path-arg)))
+    (cond
+     ((or (equal system-type 'cygwin) ;; No mono needed on cygwin or if using omnisharp-roslyn
+          (equal system-type 'windows-nt)
+          (not (s-ends-with? ".exe" server-exe-file-path-arg)))
+      args)
+     (t ; some kind of unix: linux or osx
+      (cons "mono" args)))))
+
+
+(defun omnisharp-post-message-curl-as-json-async (url params callback)
+  "Posts message to curl at URL with PARAMS asynchronously.
+On completion, the curl output is parsed as json and passed into CALLBACK."
+  (omnisharp-post-message-curl-async url params
+                                     (lambda (str)
+                                       (funcall callback (omnisharp--json-read-from-string str)))))
+
+(defun omnisharp-post-message-curl-async (url params callback)
+  "Post json stuff to url asynchronously with --data set to given params.
+On completion, CALLBACK is run with the result as it's only parameter.
+
+Returns the curl process"
+  (let* ((curl-command-plist
+          (omnisharp--get-curl-command url params))
+         (process-name (concat "* Omnisharp curl : " url "*"))
+         (process-buffer (generate-new-buffer process-name))
+         (process (apply 'start-process
+                         process-name
+                         process-buffer
+                         (plist-get curl-command-plist :command)
+                         (plist-get curl-command-plist :arguments))))
+    (set-process-sentinel
+     process
+     (lambda (proc status)
+       (unless (process-live-p proc)
+         (funcall callback
+                  (progn (let ((output (with-current-buffer process-buffer (buffer-string))))
+                           (kill-buffer process-buffer)
+                           output))))))
+    process))
+
+
+(provide 'omnisharp-http-utils)

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -11,15 +11,18 @@
 ;;;###autoload
 (defun omnisharp-post-http-message (url &optional params)
   "Post http request to server. Return result."
-  (let* ((response (omnisharp--submit-request url params))
+  (let* ((url (omnisharp--get-api-url url))
+         (response (omnisharp--submit-request url params))
          (data (elt response 3)))
     (unless data
-      (message "Error when sending request"))
+      (message "Error when sending request %s" url))
+    (when omnisharp-debug
+      (message "Response:\n%s" (prin1-to-string data)))
     data))
 
 (defun omnisharp--submit-request (url &optional params)
   (require 'request)
-  (request (omnisharp--get-api-url url)
+  (request url
            :type "POST"
            :parser 'json-read
            :sync t
@@ -27,9 +30,9 @@
            :error
            (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
                           (message "Got error: %S" error-thrown)))
-           :complete (lambda (&rest _) (message "Finished!"))
+           :complete (lambda (&rest _) (when omnisharp-debug (message "Request completed")))
            :success (cl-function
-                     (lambda (&key data &allow-other-keys) (message "Received")
+                     (lambda (&key data &allow-other-keys) (when omnisharp-debug (message "Request succeeded"))
                        ))))
 
 (defun omnisharp--server-process-sentinel (process event)

--- a/src/omnisharp-http-utils.el
+++ b/src/omnisharp-http-utils.el
@@ -1,122 +1,39 @@
 
-(defun omnisharp-post-message-curl (url &optional params)
-  "Post json stuff to url with --data set to given params. Return
-result."
-  (let ((curl-command-plist
-         (omnisharp--get-curl-command (omnisharp--get-api-url url) params)))
-    (with-temp-buffer
-      (apply 'call-process
-             (plist-get curl-command-plist :command)
-             nil ;; infile
-             (buffer-name);; destination
-             nil ;; display (no specialities needed)
-             ;; these are just args
-             (plist-get curl-command-plist :arguments))
-      (buffer-string))))
+(defun omnisharp-get-host ()
+  "Makes sure omnisharp-host is ended by / "
+  (if (string= (substring omnisharp-host -1 ) "/")
+      omnisharp-host
+    (concat omnisharp-host "/")))
 
-(defun omnisharp--get-curl-command (url params)
-  "Returns a command that may be used to communicate with the API via
-the curl program. Depends on the operating system."
-  (let ((curl-command
-         (if (equal system-type 'windows-nt)
-             (omnisharp--get-curl-command-windows-with-tmp-file url params)
-           (omnisharp--get-curl-command-unix url params))))
-    (when omnisharp-debug
-      (omnisharp--log-curl-command curl-command))
-    curl-command))
+(defun omnisharp--get-api-url (api-name)
+  (concat (omnisharp-get-host) api-name))
 
-(defun omnisharp--log-curl-command (curl-command)
-  (omnisharp--log (prin1-to-string curl-command)))
+;;;###autoload
+(defun omnisharp-post-http-message (url &optional params)
+  "Post http request to server. Return result."
+  (let* ((response (omnisharp--submit-request url params))
+         (data (elt response 3)))
+    (unless data
+      (message "Error when sending request"))
+    data))
 
-(defun omnisharp--get-curl-command-arguments-string-for-api-name
-  (params api-name)
-  "Returns the full command to call curl with PARAMS for the api API-NAME.
-Example: when called with \"getcodeactions\", returns
-\"curl (stuff) http://localhost:2000/getcodeactions (stuff)\"
-with \"stuff\" set to sensible values."
-  (let ((command-plist
-         (omnisharp--get-curl-command
-          (concat (omnisharp-get-host) api-name)
-          params)))
-    (plist-get command-plist :arguments)))
-
-(defun omnisharp--get-curl-command-unix (url params)
-  "Returns a command using plain curl that can be executed to
-communicate with the API."
-  `(:command
-    ,omnisharp--curl-executable-path
-    :arguments
-    ("--ipv4" "--silent" "-H" "Content-type: application/json"
-     "--data"
-     ,(json-encode params)
-     ,url)))
-
-(defun omnisharp--get-curl-command-windows-with-tmp-file (url params)
-  "Basically: put PARAMS to file, then create a curl command to the
-api at URL using that file as the parameters."
-  ;; TODO could optimise: short buffers need not be written to tmp
-  ;; files.
-  (omnisharp--write-json-params-to-tmp-file
-   omnisharp--windows-curl-tmp-file-path
-   (json-encode params))
-  (let ((path-with-curl-prefix
-         (concat "@"
-                 omnisharp--windows-curl-tmp-file-path
-                 )))
-    `(:command ,omnisharp--curl-executable-path
-               :arguments
-               ("--noproxy" "localhost"
-                "--silent" "-H" "Content-type: application/json"
-                "--data-binary"
-                ;; @ specifies a file path to curl
-                ,path-with-curl-prefix
-                ,url))))
-
-(defun omnisharp--write-json-params-to-tmp-file
-  (target-path stuff-to-write-to-file)
-  "Deletes the file when done."
-  (with-temp-file target-path
-    (insert stuff-to-write-to-file)))
-
-(defun omnisharp-post-message-curl-as-json (url &optional params)
-  (omnisharp--json-read-from-string
-   (omnisharp-post-message-curl url params)))
-
+(defun omnisharp--submit-request (url &optional params)
+  (require 'request)
+  (request (omnisharp--get-api-url url)
+           :type "POST"
+           :parser 'json-read
+           :sync t
+           :data (json-encode params)
+           :error
+           (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
+                          (message "Got error: %S" error-thrown)))
+           :complete (lambda (&rest _) (message "Finished!"))
+           :success (cl-function
+                     (lambda (&key data &allow-other-keys) (message "Received")
+                       ))))
 
 (defun omnisharp--server-process-sentinel (process event)
   (if (string-match "^exited abnormally" event)
       (error (concat "OmniSharp server process " event))))
-
-
-(defun omnisharp-post-message-curl-as-json-async (url params callback)
-  "Posts message to curl at URL with PARAMS asynchronously.
-On completion, the curl output is parsed as json and passed into CALLBACK."
-  (omnisharp-post-message-curl-async url params
-                                     (lambda (str)
-                                       (funcall callback (omnisharp--json-read-from-string str)))))
-
-(defun omnisharp-post-message-curl-async (url params callback)
-  "Post json stuff to url asynchronously with --data set to given params.
-On completion, CALLBACK is run with the result as it's only parameter.
-
-Returns the curl process"
-  (let* ((curl-command-plist
-          (omnisharp--get-curl-command url params))
-         (process-name (concat "* Omnisharp curl : " url "*"))
-         (process-buffer (generate-new-buffer process-name))
-         (process (apply 'start-process
-                         process-name
-                         process-buffer
-                         (plist-get curl-command-plist :command)
-                         (plist-get curl-command-plist :arguments))))
-    (set-process-sentinel
-     process
-     (lambda (proc status)
-       (unless (process-live-p proc)
-         (funcall callback
-                  (progn (let ((output (with-current-buffer process-buffer (buffer-string))))
-                           (kill-buffer process-buffer)
-                           output))))))
-    process))
 
 (provide 'omnisharp-http-utils)

--- a/src/omnisharp-server-management.el
+++ b/src/omnisharp-server-management.el
@@ -19,17 +19,18 @@ handlers in the current omnisharp--server-info."
 (defmacro comment (&rest body) nil)
 (comment (omnisharp--clear-response-handlers))
 
-(defun omnisharp--send-command-to-server (api-name contents &optional response-handler)
+(defun omnisharp--send-command-to-server (api-name contents &optional response-handler async)
   "Sends the given command to the server.
-Depending on omnisharp-use-http it will either send it via http or stdio"
+Depending on omnisharp-use-http it will either send it via http or stdio.
+The variable ASYNC has no effect when not using http."
 
   (if omnisharp-use-http
-      (omnisharp--send-command-to-server-http api-name contents response-handler)
+      (omnisharp--send-command-to-server-http api-name contents response-handler async)
     (omnisharp--send-command-to-server-stdio api-name contents response-handler)))
 
-(defun omnisharp--send-command-to-server-http (api-name contents response-handler)
+(defun omnisharp--send-command-to-server-http (api-name contents response-handler &optional async)
   "Sends the given command via curl"
-  (apply response-handler (list (omnisharp-post-http-message api-name contents))))
+  (omnisharp-post-http-message api-name response-handler contents async))
 
 (defun omnisharp--send-command-to-server-stdio (api-name contents &optional response-handler)
   "Sends the given command to the server and associates a

--- a/src/omnisharp-server-management.el
+++ b/src/omnisharp-server-management.el
@@ -29,7 +29,7 @@ Depending on omnisharp-use-http it will either send it via http or stdio"
 
 (defun omnisharp--send-command-to-server-http (api-name contents response-handler)
   "Sends the given command via curl"
-  (apply response-handler (list (omnisharp-post-message-curl-as-json api-name contents))))
+  (apply response-handler (list (omnisharp-post-http-message api-name contents))))
 
 (defun omnisharp--send-command-to-server-stdio (api-name contents &optional response-handler)
   "Sends the given command to the server and associates a

--- a/src/omnisharp-server-management.el
+++ b/src/omnisharp-server-management.el
@@ -1,4 +1,5 @@
 (defvar omnisharp--server-info nil)
+(defvar omnisharp-use-http nil "Set to t to use http instead of stdio.")
 
 (defun make-omnisharp--server-info (process)
   `((:process . ,process)
@@ -19,6 +20,18 @@ handlers in the current omnisharp--server-info."
 (comment (omnisharp--clear-response-handlers))
 
 (defun omnisharp--send-command-to-server (api-name contents &optional response-handler)
+  "Sends the given command to the server.
+Depending on omnisharp-use-http it will either send it via http or stdio"
+
+  (if omnisharp-use-http
+      (omnisharp--send-command-to-server-http api-name contents response-handler)
+    (omnisharp--send-command-to-server-stdio api-name contents response-handler)))
+
+(defun omnisharp--send-command-to-server-http (api-name contents response-handler)
+  "Sends the given command via curl"
+  (apply response-handler (list (omnisharp-post-message-curl-as-json api-name contents))))
+
+(defun omnisharp--send-command-to-server-stdio (api-name contents &optional response-handler)
   "Sends the given command to the server and associates a
 response-handler for it. The server will respond to this request
 later and the response handler will get called then.

--- a/src/omnisharp-utils.el
+++ b/src/omnisharp-utils.el
@@ -1,13 +1,4 @@
 
-(defun omnisharp-get-host ()
-  "Makes sure omnisharp-host is ended by / "
-  (if (string= (substring omnisharp-host -1 ) "/")
-      omnisharp-host
-    (concat omnisharp-host "/")))
-
-(defun omnisharp--get-api-url (api-name)
-  (concat (omnisharp-get-host) api-name))
-
 (defun omnisharp--write-quickfixes-to-compilation-buffer
   (quickfixes
    buffer-name


### PR DESCRIPTION
As per issue #216.

To enable this feature, user needs to set `omnisharp-use-http` variable to `t` and `omnisharp-host` to the remote server address (e.g `http://192.168.1.250:2000/`).

Note that when using http, `omnisharp-roslyn` server will not be started automatically. It is presumed that the user has already started it manually on the remote server.

The current `omnisharp-roslyn` server listens to the [localhost interface](https://github.com/OmniSharp/omnisharp-roslyn/blob/2c6c8a481fbdd05c4c06f5ddc720d3a9315d6062/src/OmniSharp.Host/Program.cs#L79) rather than the public one which means that it will be unreachable.
For the time being I manually built the roslyn server and changed that line to `http://{external-interface-ip}:2000/` to get it working. Ideally we'll need to send them a patch to make the listening interface configurable.

These changes require the [request](https://github.com/tkf/emacs-request) package.