### PR TITLE
[Roslyn] Use `buffer-file-name' to check for C# buffers

### DIFF
--- a/src/actions/omnisharp-auto-complete-actions.el
+++ b/src/actions/omnisharp-auto-complete-actions.el
@@ -353,12 +353,10 @@ triggers a completion immediately"
                        (omnisharp--tag-text-with-completion-info arg json-result)
                        (when allow-templating
                          ;; Do yasnippet completion
-                         (if (and omnisharp-company-template-use-yasnippet (fboundp 'yas-expand-snippet))
-                             (progn
-                               (let ((method-snippet (omnisharp--completion-result-item-get-method-snippet
-                                                      json-result)))
-                                 (when method-snippet
-                                   (omnisharp--snippet-templatify arg method-snippet json-result))))
+                         (if (and omnisharp-company-template-use-yasnippet (boundp 'yas-minor-mode) yas-minor-mode)
+                             (-when-let (method-snippet (omnisharp--completion-result-item-get-method-snippet
+							 json-result))
+			       (omnisharp--snippet-templatify arg method-snippet json-result))
                            ;; Fallback on company completion but make sure company-template is loaded.
                            ;; Do it here because company-mode is optional
                            (require 'company-template)

--- a/src/actions/omnisharp-server-actions.el
+++ b/src/actions/omnisharp-server-actions.el
@@ -19,8 +19,8 @@
   (when (get-buffer BufferName)
     (kill-buffer BufferName))
 
-  "Save all csharp buffers to ensure the server is in sync"
-  (save-some-buffers 't `(lambda() (string-equal (file-name-extension (buffer-name)) "cs")))
+  ;; Save all csharp buffers to ensure the server is in sync"
+  (save-some-buffers t (lambda () (string-equal (file-name-extension (buffer-file-name)) "cs")))
 
   (setq omnisharp--server-info
         (make-omnisharp--server-info


### PR DESCRIPTION
I use this custom Emacs setup with reverse notation for buffer names: 
```
'(uniquify-buffer-name-style (quote reverse) nil (uniquify)) 
```
so checking the `buffer-name` is not valid. For example `(file-name-extension (buffer-name))`   returns:

`"cs\\OmniSharp\\src\\omnisharp-roslyn\\csharp\\juergen\\home\\"
`

