### PR TITLE
[Roslyn] Actually use pipe for communication when starting omnisharp process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
     - sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
     - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
     - sudo apt-get -qq update
-    - sudo apt-get install -y dotnet-dev-1.0.0-rc2-002543
+    - sudo apt-get install -y dotnet-dev-1.0.0-rc2-002543 dotnet-hostfxr-1.0.2-beta-000914-00
     - dotnet --version
 
 before_script:

--- a/src/actions/omnisharp-server-actions.el
+++ b/src/actions/omnisharp-server-actions.el
@@ -24,15 +24,19 @@
 
   (setq omnisharp--server-info
         (make-omnisharp--server-info
-         ;; use a pipe for the connection instead of a pty
-         (let ((process-connection-type nil)
-               (process (start-process
-                         "OmniServer" ; process name
-                         "OmniServer" ; buffer name
-                         omnisharp-server-executable-path
-                         "--stdio" "-s" (expand-file-name path-to-project))))
-           (set-process-filter process 'omnisharp--handle-server-message)
-           process))))
+         (let ((original-process-connection-type process-connection-type))
+
+           ;; use a pipe for the connection instead of a pty
+           (setq process-connection-type nil)
+
+           (let ((process (start-process
+                           "OmniServer" ; process name
+                           "OmniServer" ; buffer name
+                           omnisharp-server-executable-path
+                           "--stdio" "-s" (expand-file-name path-to-project))))
+             (setq process-connection-type original-process-connection-type)
+             (set-process-filter process 'omnisharp--handle-server-message)
+             process)))))
 
 ;;;###autoload
 (defun omnisharp-check-alive-status ()


### PR DESCRIPTION
`let` special form was binding `process-connection-type` locally and was
not setting global variable properly (I'm new to elisp, not so sure about the details – but it appears that `let` wasn't working here)

Also set `:noquery` so emacs would not ask for confirmation to kill OmniSharp
server processes on quit.