### PR TITLE
cygpath translation

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -188,7 +188,7 @@ some cases. Work around this."
                    (Column   . ,column-number)
                    (Buffer   . ,buffer-contents))))
     (if (/= 0 (length filename-tmp))
-        (cons `(FileName . ,filename-tmp)
+        (cons (omnisharp--to-filename filename-tmp)
               params)
       params)))
 
@@ -204,7 +204,7 @@ not work on all platforms."
                    (Column   . ,column-number)
                    (Buffer   . ,buffer-contents))))
     (if (/= 0 (length filename-tmp))
-        (cons `(FileName . ,filename-tmp)
+        (cons (omnisharp--to-filename filename-tmp)
               params)
       params)))
 
@@ -216,7 +216,7 @@ QuickFix class json result."
   (omnisharp-go-to-file-line-and-column-worker
    (cdr (assoc 'Line json-result))
    (- (cdr (assoc 'Column json-result)) 1)
-   (cdr (assoc 'FileName json-result))
+   (omnisharp--get-filename json-result)
    other-window))
 
 (defun omnisharp--go-to-line-and-column (line column)
@@ -336,7 +336,7 @@ locations in the json."
                  (flycheck-error-new
                   :buffer buffer
                   :checker checker
-                  :filename (cdr (assoc 'FileName it))
+                  :filename (omnisharp--get-filename it)
                   :line (cdr (assoc 'Line it))
                   :column (cdr (assoc 'Column it))
                   :message (cdr (assoc 'Text it))
@@ -350,7 +350,7 @@ locations in the json."
 cursor at that location"
   (let* ((element-line (cdr (assoc 'Line element)))
          (element-column (cdr (assoc 'Column element)))
-         (element-filename (cdr (assoc 'FileName element)))
+         (element-filename (omnisharp--get-filename element))
          (use-buffer (current-buffer)))
     (save-excursion
       (omnisharp-go-to-file-line-and-column-worker
@@ -380,7 +380,7 @@ cursor at that location"
     (error nil)))
 
 (defun omnisharp-format-find-output-to-ido (item)
-  (-let* ((('FileName filename) item))
+  (let (filename (omnisharp--get-filename item))
     (cons
      (cons
       (car (car item))

--- a/src/actions/omnisharp-current-symbol-actions.el
+++ b/src/actions/omnisharp-current-symbol-actions.el
@@ -149,14 +149,13 @@ name to rename to, defaulting to the current name of the symbol."
       (omnisharp-go-to-file-line-and-column location-before-rename)
 
       (message "Rename complete in files: \n%s"
-               (-interpose "\n" (--map (cdr (assoc 'FileName it))
+               (-interpose "\n" (--map (omnisharp--get-filename it)
                                        modified-file-responses))))))
 
 (defun omnisharp--apply-text-changes (modified-file-response)
-  (-let (((&alist 'Changes changes
-                  'FileName file-name) modified-file-response))
+  (-let (((&alist 'Changes changes) modified-file-response))
     (omnisharp--update-files-with-text-changes
-     file-name
+     (omnisharp--get-filename modified-file-response)
      (omnisharp--vector-to-list changes))))
 
 (defun omnisharp-rename-interactively ()

--- a/src/actions/omnisharp-navigation-actions.el
+++ b/src/actions/omnisharp-navigation-actions.el
@@ -8,7 +8,7 @@ argument, use another window."
    "gotodefinition"
    (omnisharp--get-request-object)
    (lambda (response)
-     (if (null (cdr (assoc 'FileName response)))
+     (if (null (omnisharp--get-filename response))
          (message
           "Cannot go to definition as none was returned by the API.")
        (omnisharp-go-to-file-line-and-column response other-window)))))
@@ -107,7 +107,7 @@ ido-completing-read. Returns the chosen element."
     (assoc 'QuickFixes)
     (cdr)
     (omnisharp--vector-to-list)
-    (--map (cdr (assoc 'FileName it)))))
+    (--map (omnisharp--get-filename it))))
 
 (defun omnisharp-navigate-to-solution-file-then-file-member
   (&optional other-window)

--- a/src/actions/omnisharp-server-actions.el
+++ b/src/actions/omnisharp-server-actions.el
@@ -27,7 +27,7 @@
 		   "OmniServer" ; process name
 		   "OmniServer" ; buffer name
 		   omnisharp-server-executable-path
-		   "--stdio" "-s" (expand-file-name path-to-project))
+		   "--stdio" "-s" (omnisharp--path-to-server (expand-file-name path-to-project)))
              (set-process-filter 'omnisharp--handle-server-message)
              (set-process-sentinel (lambda (process event)
                                      (when (memq (process-status process) '(exit signal))

--- a/src/actions/omnisharp-solution-actions.el
+++ b/src/actions/omnisharp-solution-actions.el
@@ -7,7 +7,7 @@
   (let ((params (omnisharp--get-request-object)))
     (omnisharp-add-to-solution-worker params)
     (message "Added %s to the solution."
-             (cdr (assoc 'FileName params)))))
+             (omnisharp--get-filename params))))
 
 (defun omnisharp-add-to-solution-dired-selected-files ()
   "Add the files currently selected in dired to the current solution."
@@ -15,7 +15,7 @@
   (let ((selected-files (dired-get-marked-files)))
     (--each selected-files
       (let ((params
-             (cons `(FileName . ,it)
+             (cons (omnisharp--to-filename it)
                    (omnisharp--get-request-object))))
         (omnisharp-add-to-solution-worker params))
       (message "Added %s files to the solution."

--- a/src/omnisharp-helm-integration.el
+++ b/src/omnisharp-helm-integration.el
@@ -9,7 +9,7 @@
     (cons
      (format "%s(%s): %s"
              (propertize (file-name-nondirectory
-                          (cdr (assoc 'FileName candidate)))
+                          (omnisharp--get-filename candidate))
                          'face 'helm-grep-file)
              (propertize (number-to-string (cdr (assoc 'Line candidate)))
                          'face 'helm-grep-lineno)
@@ -67,7 +67,7 @@
     "Convert a quickfix entry into helm output"
     (cons
      (format "%s : %s"
-             (propertize (cdr (assoc 'FileName candidate))
+             (propertize (omnisharp--get-filename candidate)
                          'face 'helm-grep-file)
              (nth 0 (split-string (cdr (assoc 'Text candidate)) "(")))
      candidate)))

--- a/src/omnisharp-utils.el
+++ b/src/omnisharp-utils.el
@@ -1,3 +1,18 @@
+(defun omnisharp--path-to-server (path)
+  (if (and path (eq system-type 'cygwin))
+      (cygwin-convert-file-name-to-windows path)
+    path))
+
+(defun omnisharp--path-from-server (path)
+  (if (and path (eq system-type 'cygwin))
+      (cygwin-convert-file-name-from-windows path)
+    path))
+
+(defun omnisharp--get-filename (item)
+  (omnisharp--path-from-server (cdr (assoc 'FileName item))))
+
+(defun omnisharp--to-filename (path)
+  `(FileName . ,(omnisharp--path-to-server path)))
 
 (defun omnisharp--write-quickfixes-to-compilation-buffer
   (quickfixes
@@ -63,7 +78,7 @@ recognizes, so that the user may jump to the results."
   "Converts a single element of a /findusages JSON response to a
 format that the compilation major mode understands and lets the user
 follow results to the locations in the actual files."
-  (let ((filename (cdr (assoc 'FileName json-result-single-element)))
+  (let ((filename (omnisharp--get-filename json-result-single-element))
         (text (cdr (assoc 'Text json-result-single-element)))
         (line (cdr (assoc 'Line json-result-single-element)))
         (column (cdr (assoc 'Column json-result-single-element)))


### PR DESCRIPTION
omnisharp-roslyn doesn't have cygpath translation like the old omnisharp.  This allows it to be used with cygwin emacs.