### PR TITLE
move to char instead of column

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -221,7 +221,7 @@ QuickFix class json result."
 (defun omnisharp--go-to-line-and-column (line column)
   (goto-char (point-min))
   (forward-line (1- line))
-  (move-to-column (max 0 column)))
+  (forward-char (max 0 column)))
 
 (defun omnisharp-go-to-file-line-and-column-worker (line
                                                     column


### PR DESCRIPTION
I need this to get correct jump locations from omnisharp-roslyn.

Do we still want to support the old omnisharp server?