### PR TITLE
Fix helm-find-symbols for windows paths

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -1335,8 +1335,8 @@ contents with the issue at point fixed."
                                      :matchplugin nil
                                      :match '((lambda (candidate) (string-match-p
                                                                    helm-pattern
-                                                                   (nth 1 (split-string
-                                                                           candidate ":" t)))))
+                                                                   (car (last (split-string
+                                                                               candidate ":" t))))))
                                      :candidates 'omnisharp--helm-find-symbols-candidates)
           :buffer "*Omnisharp Symbols*"
           :truncate-lines t))


### PR DESCRIPTION
Candidates for symbols appear like this for windows paths:

"C:\SomeLocation\File.cs : symbol"

In this case the match fn matches against the file path rather than the
symbol as the string is split on ":" and the second substring is always
checked

Instead now always use the last substring so that paths may have ":"
characters in them without messing up the matching

Fixes #238
