### PR TITLE
Update dash dependency "20141201.2206" -> "2.13.0"

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -4,7 +4,7 @@
 ;; Author: Mika Vilpas
 ;; Version: 3.4
 ;; Url: https://github.com/sp3ctum/omnisharp-emacs
-;; Package-Requires: ((json "1.2") (flycheck "0.25.1") (dash "20141201.2206") (auto-complete "1.4") (popup "0.5.1") (csharp-mode "0.8.7") (cl-lib "0.5") (s "1.9.0"))
+;; Package-Requires: ((json "1.2") (flycheck "0.25.1") (dash "2.13.0") (auto-complete "1.4") (popup "0.5.1") (csharp-mode "0.8.7") (cl-lib "0.5") (s "1.9.0"))
 ;; Keywords: csharp c# IDE auto-complete intellisense
 
 ;;; Commentary:


### PR DESCRIPTION
This also represents a bump to a stable version number allowing package
install to succeed from melpa-stable only
