### PR TITLE
Don't flycheck if omnisharp server is not running

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -340,9 +340,10 @@ locations in the json."
                  :line (cdr (assoc 'Line it))
                  :column (cdr (assoc 'Column it))
                  :message (cdr (assoc 'Text it))
-                 :level (if (equal (cdr (assoc 'LogLevel it)) "Warning")
-                            'warning
-                          'error)))
+                 :level (pcase (cdr (assoc 'LogLevel it))
+                          ("Warning" 'warning)
+                          ("Hidden" 'info)
+                          (_ 'error))))
               errors))))
 
 (defun omnisharp--imenu-make-marker (element)

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -323,7 +323,7 @@ CALLBACK is the status callback passed by Flycheck."
   "A csharp source syntax checker using the OmniSharp server process
    running in the background"
   :start #'omnisharp--flycheck-start
-  :predicate (lambda () omnisharp-mode))
+  :predicate (lambda () (and omnisharp-mode omnisharp--server-info)))
 
 (defun omnisharp--flycheck-error-parser (response checker buffer)
   "Takes a QuickFixResponse result. Returns flycheck errors created based on the

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -328,23 +328,20 @@ CALLBACK is the status callback passed by Flycheck."
 (defun omnisharp--flycheck-error-parser (response checker buffer)
   "Takes a QuickFixResponse result. Returns flycheck errors created based on the
 locations in the json."
-  (let* ((errors (omnisharp--vector-to-list
-                 (cdr (assoc 'QuickFixes response)))))
-
-    (when (not (equal (length errors) 0))
-      (mapcar (lambda (it)
-                (flycheck-error-new
-                 :buffer buffer
-                 :checker checker
-                 :filename (cdr (assoc 'FileName it))
-                 :line (cdr (assoc 'Line it))
-                 :column (cdr (assoc 'Column it))
-                 :message (cdr (assoc 'Text it))
-                 :level (pcase (cdr (assoc 'LogLevel it))
-                          ("Warning" 'warning)
-                          ("Hidden" 'info)
-                          (_ 'error))))
-              errors))))
+  (->> (omnisharp--vector-to-list
+        (cdr (assoc 'QuickFixes response)))
+       (mapcar (lambda (it)
+                 (flycheck-error-new
+                  :buffer buffer
+                  :checker checker
+                  :filename (cdr (assoc 'FileName it))
+                  :line (cdr (assoc 'Line it))
+                  :column (cdr (assoc 'Column it))
+                  :message (cdr (assoc 'Text it))
+                  :level (pcase (cdr (assoc 'LogLevel it))
+                           ("Warning" 'warning)
+                           ("Hidden" 'info)
+                           (_ 'error)))))))
 
 (defun omnisharp--imenu-make-marker (element)
   "Takes a QuickCheck element and returns the position of the

--- a/src/actions/omnisharp-server-actions.el
+++ b/src/actions/omnisharp-server-actions.el
@@ -37,6 +37,10 @@
                            "--stdio" "-s" (expand-file-name path-to-project))))
              (setq process-connection-type original-process-connection-type)
              (set-process-filter process 'omnisharp--handle-server-message)
+             (set-process-sentinel process (lambda (process event)
+                                             (when (memq (process-status process) '(exit signal))
+					       (message "OmniSharp server terminated")
+                                               (setq omnisharp--server-info nil))))
              process)))))
 
 ;;;###autoload

--- a/src/actions/omnisharp-server-actions.el
+++ b/src/actions/omnisharp-server-actions.el
@@ -25,23 +25,18 @@
 
   (setq omnisharp--server-info
         (make-omnisharp--server-info
-         (let ((original-process-connection-type process-connection-type))
-
-           ;; use a pipe for the connection instead of a pty
-           (setq process-connection-type nil)
-
-           (let ((process (start-process
-                           "OmniServer" ; process name
-                           "OmniServer" ; buffer name
-                           omnisharp-server-executable-path
-                           "--stdio" "-s" (expand-file-name path-to-project))))
-             (setq process-connection-type original-process-connection-type)
-             (set-process-filter process 'omnisharp--handle-server-message)
-             (set-process-sentinel process (lambda (process event)
-                                             (when (memq (process-status process) '(exit signal))
-					       (message "OmniSharp server terminated")
-                                               (setq omnisharp--server-info nil))))
-             process)))))
+         ;; use a pipe for the connection instead of a pty
+         (let ((process-connection-type nil))
+           (-doto (start-process
+		   "OmniServer" ; process name
+		   "OmniServer" ; buffer name
+		   omnisharp-server-executable-path
+		   "--stdio" "-s" (expand-file-name path-to-project))
+             (set-process-filter 'omnisharp--handle-server-message)
+             (set-process-sentinel (lambda (process event)
+                                     (when (memq (process-status process) '(exit signal))
+                                       (message "OmniSharp server terminated")
+                                       (setq omnisharp--server-info nil)))))))))
 
 ;;;###autoload
 (defun omnisharp-check-alive-status ()


### PR DESCRIPTION
If flycheck was enabled before starting the omnisharp server, it was not
possible to use any checkers at all, because the generic
`omnisharp--flycheck-start' was invoked but did never call the the
flycheck callback function, so (flycheck-running-p) returned t forever.

Refs #178