### PR TITLE
[roslyn] fix csharp-omnisharp-codecheck flycheck checker registration

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -323,6 +323,7 @@ CALLBACK is the status callback passed by Flycheck."
   "A csharp source syntax checker using the OmniSharp server process
    running in the background"
   :start #'omnisharp--flycheck-start
+  :modes '(csharp-mode)
   :predicate (lambda () omnisharp-mode))
 
 (defun omnisharp--flycheck-error-parser (response checker buffer)


### PR DESCRIPTION
current code fails on latest flycheck where :modes key is required now
see http://www.lunaryorn.com/2014/12/03/generic-syntax-checkers-in-flycheck.html

`Like a regular command syntax checker, a generic checker needs :modes and (optionally) a :predicate...`