### PR TITLE
omnisharp.el: fix eldoc worker to use the generic send-to-server fn

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -456,8 +456,8 @@ cursor at that location"
 (defun omnisharp--eldoc-worker ()
   "Gets type information from omnisharp server about the symbol at point"
   (omnisharp--completion-result-get-item 
-   (omnisharp-post-http-message
-    (concat (omnisharp--get-host) "typelookup")
+   (omnisharp--send-command-to-server
+    "typelookup"
     (omnisharp--get-request-object))
    'Type))
 


### PR DESCRIPTION
Currently it always sends eldoc requests via HTTP which does not work if
your server is in stdio mode. This gets rid of error messages on `*Messages*` buffer if you have eldoc enabled. Those messages look like this:
```Error from http://localhost:2000/http://localhost:2000/typelookup : (error . "exited abnormally with code 7
")```

(minor) issue introduced to https://github.com/OmniSharp/omnisharp-emacs/pull/223