### PR TITLE
Update flycheck checker

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -894,7 +894,7 @@ server process running in the background."
                   (omnisharp--flycheck-error-parser-raw-json
                    output checker buffer))
 
-  :predicate (lambda () omnisharp-mode))
+  :modes (omnisharp-mode))
 
 (defun omnisharp--flycheck-error-parser-raw-json (output checker buffer)
   "Takes either a QuickFixResponse or a SyntaxErrorsResponse as a


### PR DESCRIPTION
Similar fix as https://github.com/OmniSharp/omnisharp-emacs/pull/245 but for master:

current code fails on latest flycheck where :modes key is required now
see http://www.lunaryorn.com/2014/12/03/generic-syntax-checkers-in-flycheck.html

Like a regular command syntax checker, a generic checker needs :modes and (optionally) a :predicate...