### PR TITLE
[roslyn] Revive omnisharp-stop-server and omnisharp-reload-solution

### DIFF
--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -1,4 +1,6 @@
 (defvar omnisharp--server-info nil)
+(defvar omnisharp--last-project-path nil)
+(defvar omnisharp--restart-server-on-stop nil)
 (defvar omnisharp-use-http nil "Set to t to use http instead of stdio.")
 
 (defun make-omnisharp--server-info (process)


### PR DESCRIPTION
This my attempt at reviving those two interactive commands where I got tired of killing the server manually and then restarting by hand.

Note that I do not try to issue a command to omnisharp-server to reload
the project (which is probably how it should eventually be) -- I just
kill the old process and restart it with the previously used project
filename/directory name.

This is basically request-for-comments PR at this moment.
