### PR TITLE
Support flycheck in csharp-mode

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -894,7 +894,7 @@ server process running in the background."
                   (omnisharp--flycheck-error-parser-raw-json
                    output checker buffer))
 
-  :modes (omnisharp-mode))
+  :modes (csharp-mode))
 
 (defun omnisharp--flycheck-error-parser-raw-json (output checker buffer)
   "Takes either a QuickFixResponse or a SyntaxErrorsResponse as a


### PR DESCRIPTION
This could be an issue with my setup, but after upgrading to the latest version I couldn't get flycheck to run.

I seem to have`csharp-mode` as my major-mode, whereas `csharp-omnisharp-codecheck` expects `omnisharp-mode`.  I had to make this change to get things to work.

I'm no expert with this stuff, so happy to believe this is a problem with my .emacs file.
Currently I have:

```
(if (require 'omnisharp nil 'noerror)
    (progn
      (require 'company)
      (setq omnisharp--curl-executable-path "~/emacs-env/curl.exe")
      (setq omnisharp-server-executable-path "~/emacs-env/omnisharp-server/OmniSharp/bin/Release/OmniSharp.exe")
      (push 'company-omnisharp company-backends)
      (add-hook 'csharp-mode-hook 'company-mode)
      (add-hook 'csharp-mode-hook 'omnisharp-mode)
      (define-key omnisharp-mode-map (kbd "M-.") 'omnisharp-go-to-definition)
      )
  )
```

Should I see `omnisharp-mode` as the major-mode?  If so, what am I doing wrong?

Thanks in advance for any help.
