### PR TITLE
fix omnisharp-current-type-information to work with the kill ring

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -738,7 +738,7 @@ the user selects a completion and the completion is inserted."
 argument, add the displayed result to the kill ring. This can be used
 to insert the result in code, for example."
   (interactive "P")
-  (omnisharp-current-type-information-worker 'Type))
+  (omnisharp-current-type-information-worker 'Type (if add-to-kill-ring add-to-kill-ring)))
 
 (defun omnisharp-current-type-documentation (&optional add-to-kill-ring)
   "Display documentation of the current type under point. With prefix


### PR DESCRIPTION
> before this change, omnisharp-current-type-information-to-kill-ring
> would not actually add anything to the kill ring. now it does by
> correctly utilizing the add-to-kill-ring parameter.

To demonstrate, go to `<menu-bar> <OmniSharp> <Current symbol> <Show type and add it to kill
ring>`. It doesn't actually add anything to the kill ring. It does, however, output the type information in the `*Messages*` buffer, but this is still not in keeping with what the docstrings here indicate. The culprit here is the invocation of `omnisharp-current-type-information-worker` in `omnisharp-current-type-information`:
```lisp
(omnisharp-current-type-information-worker 'Type)
```
See the problem? `omnisharp-current-type-information-worker` isn't getting its `add-to-kill-ring` argument that is passed to `omnisharp-current-type-information` in `omnisharp-current-type-information-to-kill-ring`. This change fixes that issue so that the kill ring is now being added to as advertised in the docstrings and README file.