### PR TITLE
Properly handle unparsable server input in omnisharp--json-read-from-string

### DIFF
--- a/omnisharp-server-actions.el
+++ b/omnisharp-server-actions.el
@@ -3,8 +3,8 @@
   :type '(choice (const :tag "Not Set" nil) string))
 
 (defun omnisharp--do-server-start (path-to-project)
-  (message (format "Starting OmniSharpServer using project folder/solution file: %s" path-to-project))
-  (message "using the server at: %s" omnisharp-server-executable-path)
+  (message (format "omnisharp-emacs: Starting OmniSharpServer using project folder/solution file: %s" path-to-project))
+  (message "omnisharp-emacs: using the server at: %s" omnisharp-server-executable-path)
 
   ;; Save all csharp buffers to ensure the server is in sync"
   (save-some-buffers t (lambda () (string-equal (file-name-extension (buffer-file-name)) "cs")))
@@ -26,7 +26,7 @@
              (set-process-filter 'omnisharp--handle-server-message)
              (set-process-sentinel (lambda (process event)
                                      (when (memq (process-status process) '(exit signal))
-                                       (message "OmniSharp server terminated")
+                                       (message "omnisharp-emacs: OmniSharp server terminated")
                                        (setq omnisharp--server-info nil)
                                        (if omnisharp--restart-server-on-stop
                                            (omnisharp--do-server-start omnisharp--last-project-path))))))))))

--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -114,7 +114,11 @@ process buffer, and handle them as server events"
 
 (defun omnisharp--log-log-packet (packet)
   (-let (((&alist 'LogLevel log-level
+                  'Name name
                   'Message message) (cdr (assoc 'Body packet))))
+    (when (and (equal log-level "INFORMATION")
+               (equal name "OmniSharp.Startup"))
+      (message (concat "omnisharp-emacs: " name ", " message)))
     (when (equal log-level "ERROR")
       (message (format "<-- OmniSharp server error: %s"
                        (-first-item (s-lines message)))))

--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -159,8 +159,11 @@ its type."
           ((omnisharp--event-packet? packet)
            (omnisharp--handle-event-packet packet))
 
-          (t (omnisharp--log (format "<-- Received an unknown server packet: %s"
-                                     (prin1-to-string packet)))))))
+          (t (progn
+               (omnisharp--log (format "<-- Received an unknown server packet: %s"
+                                       (prin1-to-string packet)))
+               (message (concat "omnisharp-emacs: an unknown packet was received from the server;"
+                                " set omnisharp-debug to t and inspect *omnisharp-debug* buffer")))))))
 
 (defun omnisharp--remove-response-handler (server-info request-id)
   (setcdr (assoc :response-handlers server-info)

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -150,7 +150,8 @@ the OmniSharp server understands."
 (defun omnisharp--json-read-from-string (json-string
                                          &optional error-message)
   "Deserialize the given JSON-STRING to a lisp object. If
-something goes wrong, return a human-readable warning."
+something goes wrong, return a pseudo-packet with keys
+ServerMessageParseError and ServerMessage."
   (condition-case possible-error
       (json-read-from-string json-string)
     (error
@@ -158,10 +159,9 @@ something goes wrong, return a human-readable warning."
        (omnisharp--log (format "omnisharp--json-read-from-string error: %s reading input %s"
                                possible-error
                                json-string)))
-     (let ((error-message-or-default (or error-message
-                                         "Error communicating to the OmniSharpServer instance")))
-       (message error-message-or-default)
-       '((ServerMessageParseError . error-message))))))
+     '((ServerMessageParseError . (or error-message
+                                      "Error communicating to the OmniSharpServer instance"))
+       (ServerMessage . json-string)))))
 
 (defun omnisharp--replace-symbol-in-buffer-with (symbol-to-replace
                                                  replacement-string)

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -158,8 +158,10 @@ something goes wrong, return a human-readable warning."
        (omnisharp--log (format "omnisharp--json-read-from-string error: %s reading input %s"
                                possible-error
                                json-string)))
-     (message (or error-message
-                  "Error communicating to the OmniSharpServer instance")))))
+     (let ((error-message-or-default (or error-message
+                                         "Error communicating to the OmniSharpServer instance")))
+       (message error-message-or-default)
+       '((ServerMessageParseError . error-message))))))
 
 (defun omnisharp--replace-symbol-in-buffer-with (symbol-to-replace
                                                  replacement-string)

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -150,8 +150,8 @@ the OmniSharp server understands."
 (defun omnisharp--json-read-from-string (json-string
                                          &optional error-message)
   "Deserialize the given JSON-STRING to a lisp object. If
-something goes wrong, return a pseudo-packet with keys
-ServerMessageParseError and ServerMessage."
+something goes wrong, return a pseudo-packet alist with keys
+ServerMessageParseError and Message."
   (condition-case possible-error
       (json-read-from-string json-string)
     (error
@@ -159,9 +159,10 @@ ServerMessageParseError and ServerMessage."
        (omnisharp--log (format "omnisharp--json-read-from-string error: %s reading input %s"
                                possible-error
                                json-string)))
-     '((ServerMessageParseError . (or error-message
-                                      "Error communicating to the OmniSharpServer instance"))
-       (ServerMessage . json-string)))))
+     (list (cons 'ServerMessageParseError
+                 (or error-message "Error communicating to the OmniSharpServer instance"))
+           (cons 'Message
+                 json-string)))))
 
 (defun omnisharp--replace-symbol-in-buffer-with (symbol-to-replace
                                                  replacement-string)


### PR DESCRIPTION
Before, in case input was not a proper JSON, the function would emit an
error message with the type of a 'string' as return value from condition-case
'error' handling. This did not bode well with omnisharp--handle-server-event
which was expecting an alist.

This fix will make omnisharp--json-read-from-string to return a dummy alist with
((ServerMessageParseError . "<error-message>")) which will be then properly
ignored by omnisharp--handle-server-event.

This does NOT completely fix #280 but is one step towards it on
the client side.

I still get these 3 lines on startup from the server that are obviously not
JSON:
```
OmniSharp: --stdio -s /Users/bob/src/test/test.sln
Discovered Mono file path: /Library/Frameworks/Mono.framework/Versions/Current/bin//mono
Resolved symbolic link for Mono file path: /Library/Frameworks/Mono.framework/Versions/4.8.0/bin/mono-sgen32
```