### PR TITLE
Fix insertion of completions from popup.

### DIFF
--- a/omnisharp-auto-complete-actions.el
+++ b/omnisharp-auto-complete-actions.el
@@ -609,7 +609,7 @@ current buffer."
             (save-excursion
               (search-backward (omnisharp--current-word-or-empty-string)))))
 
-      (if (and completion-snippet omnisharp-company-template-use-yasnippet (fboundp 'yas-expand-snippet))
+      (if (and completion-snippet omnisharp-company-template-use-yasnippet (boundp 'yas-minor-mode) yas-minor-mode)
           (yas-expand-snippet
            completion-snippet
            current-symbol-start-point


### PR DESCRIPTION
Correct the behavior of the popup when YASnippet is installed but not active in
the current buffer.

Without this patch, the package doesn’t check for yas-minor-mode before it tries inserting a snippet. This means that the snippet expand fails silently (apparently errors are suppressed, another possible issue there) when YAS is installed but not active in the current buffer, making completion useless. The fix is to check whether the minor mode is enabled before trying to use YAS insertion.