### PR TITLE
[WIP] Show candidate type for auto-complete

### DIFF
--- a/omnisharp-auto-complete-actions.el
+++ b/omnisharp-auto-complete-actions.el
@@ -216,7 +216,9 @@ and complete members."
              . ,(omnisharp--t-or-json-false
                  omnisharp-auto-complete-want-importable-types))
 
-            (WordToComplete . ,(thing-at-point 'symbol)))
+            (WordToComplete . ,(thing-at-point 'symbol))
+
+            (WantKind . t))
 
           (omnisharp--get-request-object)))
 

--- a/omnisharp-auto-complete-actions.el
+++ b/omnisharp-auto-complete-actions.el
@@ -672,6 +672,9 @@ is a more sophisticated matching framework than what popup.el offers."
       (when required-namespace-import
         (omnisharp--insert-namespace-import required-namespace-import)))))
 
+(defun omnisharp--method-name-p (name)
+  (string-match "(.*)$" name))
+
 (defun omnisharp--convert-auto-complete-result-to-popup-format (json-result-alist)
   (mapcar
    (-lambda ((&alist 'DisplayText display-text
@@ -681,6 +684,7 @@ is a more sophisticated matching framework than what popup.el offers."
                      'RequiredNamespaceImport require-ns-import))
             (popup-make-item display-text
                              :value (propertize completion-text 'Snippet snippet 'RequiredNamespaceImport require-ns-import)
+                             :symbol (if (omnisharp--method-name-p display-text) "f" "v")
                              :document description))
    json-result-alist))
 

--- a/omnisharp-auto-complete-actions.el
+++ b/omnisharp-auto-complete-actions.el
@@ -672,8 +672,34 @@ is a more sophisticated matching framework than what popup.el offers."
       (when required-namespace-import
         (omnisharp--insert-namespace-import required-namespace-import)))))
 
-(defun omnisharp--method-name-p (name)
-  (string-match "(.*)$" name))
+(defun omnisharp--convert-auto-complete-kind-to-popup-symbol-value (kind)
+  (pcase kind
+    ;; auto-complete's recommended rules
+    ;;; Symbol
+    ("Keyword" "s")
+    ;;; Function, Method
+    ("Method" "f")
+    ("Function" "f")
+    ("Constructor" "f")
+    ;;; Variable
+    ("Field" "v")
+    ("Variable" "v")
+    ("Property" "v")
+    ;;; Constant
+    ;;; Abbreviation
+    ("Value" "a")
+    ;; original rules
+    ("Text" "")
+    ("Class" "t")
+    ("Interface" "i")
+    ("Enum" "e")
+    ("Module" "m")
+    ("Unit" "u")
+    ("Snippet" "")
+    ("Color" "")
+    ("File" "f")
+    ("Reference" "r")
+    ))
 
 (defun omnisharp--convert-auto-complete-result-to-popup-format (json-result-alist)
   (mapcar
@@ -684,7 +710,7 @@ is a more sophisticated matching framework than what popup.el offers."
                      'RequiredNamespaceImport require-ns-import))
             (popup-make-item display-text
                              :value (propertize completion-text 'Snippet snippet 'RequiredNamespaceImport require-ns-import)
-                             :symbol (if (omnisharp--method-name-p display-text) "f" "v")
+                             :symbol (omnisharp--convert-auto-complete-kind-to-popup-symbol-value kind)
                              :document description))
    json-result-alist))
 


### PR DESCRIPTION
# Description

It adds the feature to show candidate type in auto-complete's candidate list.

- methods ... `f`
- variables, constants ... `v`

# Before

![2017-05-31 18 36 05](https://cloud.githubusercontent.com/assets/377137/26625809/3719ba9a-4630-11e7-8ac6-eb676bce400b.png)

# After

![2017-05-31 18 36 44](https://cloud.githubusercontent.com/assets/377137/26625815/3bde90e6-4630-11e7-957c-d737aaf4f18f.png)
