### PR TITLE
Show candidate kind in auto-complete popup

### DIFF
--- a/omnisharp-auto-complete-actions.el
+++ b/omnisharp-auto-complete-actions.el
@@ -216,7 +216,9 @@ and complete members."
              . ,(omnisharp--t-or-json-false
                  omnisharp-auto-complete-want-importable-types))
 
-            (WordToComplete . ,(thing-at-point 'symbol)))
+            (WordToComplete . ,(thing-at-point 'symbol))
+
+            (WantKind . t))
 
           (omnisharp--get-request-object)))
 
@@ -672,15 +674,45 @@ is a more sophisticated matching framework than what popup.el offers."
       (when required-namespace-import
         (omnisharp--insert-namespace-import required-namespace-import)))))
 
+(defun omnisharp--convert-auto-complete-kind-to-popup-symbol-value (kind)
+  (pcase kind
+    ;; auto-complete's recommended rules
+    ;;; Symbol
+    ("Keyword" "s")
+    ;;; Function, Method
+    ("Method" "f")
+    ("Function" "f")
+    ("Constructor" "f")
+    ;;; Variable
+    ("Field" "v")
+    ("Variable" "v")
+    ("Property" "v")
+    ;;; Constant
+    ;;; Abbreviation
+    ("Value" "a")
+    ;; original rules
+    ("Text" "")
+    ("Class" "t")
+    ("Interface" "i")
+    ("Enum" "e")
+    ("Module" "m")
+    ("Unit" "u")
+    ("Snippet" "")
+    ("Color" "")
+    ("File" "f")
+    ("Reference" "r")))
+
 (defun omnisharp--convert-auto-complete-result-to-popup-format (json-result-alist)
   (mapcar
    (-lambda ((&alist 'DisplayText display-text
                      'CompletionText completion-text
                      'Description description
                      'Snippet snippet
-                     'RequiredNamespaceImport require-ns-import))
+                     'RequiredNamespaceImport require-ns-import
+                     'Kind kind))
             (popup-make-item display-text
                              :value (propertize completion-text 'Snippet snippet 'RequiredNamespaceImport require-ns-import)
+                             :symbol (omnisharp--convert-auto-complete-kind-to-popup-symbol-value kind)
                              :document description))
    json-result-alist))
 

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -251,7 +251,8 @@ expected output in that buffer"
              (RequiredNamespaceImport . nil)
              (DisplayText . "Verbosity Verbose - display text")
              (Description . ,description)
-             (CompletionText . ,completion-text))])
+             (CompletionText . ,completion-text)
+             (Kind . "Verbose"))])
          (converted-popup-item
           (nth 0
                (omnisharp--convert-auto-complete-result-to-popup-format


### PR DESCRIPTION
# Description

This pull request has same purpose of #309, and has better implementation which based on @razzmatazz's advice.

Roslyn server has a feature to return candidate kind in completion response. I modified the completion request to use enable this feature, and just use it to show kind in auto-complete's popup.

https://github.com/auto-complete/auto-complete/blob/b152753165cd1f3e4920157998332417af74784f/doc/manual.md#symbol

According to this document, auto-complete supports to show any character as candidate kind, but there is some recommended rules.

- Symbol ... `s`
- Function, Method ... `f`
- Variable ... `v`
- Constant ... `c`
- Abbreviation ... `a`
- Dictionary ... `d`

I followed those recommended rules as I could. 