### PR TITLE
Snippet expanding feature for auto-complete using yasnippet

### DIFF
--- a/omnisharp-auto-complete-actions.el
+++ b/omnisharp-auto-complete-actions.el
@@ -166,6 +166,16 @@ information.")
   :type '(choice (const :tag "Yes" t)
                  (const :tag "No" nil)))
 
+;; auto-complete-mode integration
+(defcustom omnisharp-auto-complete-template-use-yasnippet t
+  "Set to t if you want completion to happen via yasnippet
+  otherwise fall back on auto-complete's templating. Requires yasnippet
+  to be installed"
+
+  :group 'omnisharp
+  :type '(choice (const :tag "Yes" t)
+                 (const :tag "No" nil)))
+
 (defun omnisharp-auto-complete (&optional invert-importable-types-setting)
   "If called with a prefix argument, will complete types that are not
 present in the current namespace or imported namespaces, inverting the
@@ -232,7 +242,25 @@ and complete members."
 ;; The library only seems to accept completions that have the same
 ;; leading characters as results. Oh well.
 (defvar ac-source-omnisharp
-  '((candidates . omnisharp--get-auto-complete-result-in-popup-format)))
+  '((candidates . omnisharp--get-auto-complete-result-in-popup-format)
+    (action . omnisharp--ac-expand)))
+
+(defun omnisharp--ac-expand()
+  (interactive)
+  (let* ((begin-point
+          (car ac-last-completion))
+         (completion-text
+          (cdr ac-last-completion))
+         (completion-value
+          (get-text-property 0 'value completion-text))
+         (completion-snippet
+          (get-text-property 0 'Snippet completion-value)))
+    (if (and
+         completion-snippet
+         omnisharp-auto-complete-template-use-yasnippet
+         (boundp 'yas-minor-mode)
+         yas-minor-mode)
+        (yas-expand-snippet completion-snippet begin-point))))
 
 (defun ac-complete-omnisharp nil
   (interactive)


### PR DESCRIPTION
# Description

This Pull Request adds the feature to expand method-name candidates as snippet using yasnippet.
The company-mode's source already has a same feature, but auto-complete's one doesn't. so I implemented this.

User can disable this feature by setting `omnisharp-auto-complete-template-use-yasnippet` to `nil`.

## Before

![screen capture on 2017-06-03 at 22-53-41](https://cloud.githubusercontent.com/assets/377137/26754189/9cd180b6-48b0-11e7-9cd3-928841beddc6.gif)

Candidate's display text will be inserted as is. User need to delete type info and sample arg name manually.

## After

![screen capture on 2017-06-03 at 13-02-08-1](https://cloud.githubusercontent.com/assets/377137/26754192/a8718ab0-48b0-11e7-82dc-3fc01c7694da.gif)

Candidate will be inserted as snippet, so user can write args easily.