### PR TITLE
start OmniSharp from dotnet cli

### DIFF
--- a/omnisharp-server-actions.el
+++ b/omnisharp-server-actions.el
@@ -21,7 +21,7 @@
            (-doto (start-process
                    "OmniServer" ; process name
                    "OmniServer" ; buffer name
-                   omnisharp-server-executable-path
+                   dotnet-path omnisharp-server-executable-path
                    "--stdio" "-s" (omnisharp--path-to-server (expand-file-name path-to-project)))
              (set-process-filter 'omnisharp--handle-server-message)
              (set-process-sentinel (lambda (process event)


### PR DESCRIPTION
from my knowledge one can only start dotnetcore apps from the dotnet cli(in linux). it works in spacemacs with dotnet-path set to /usr/bin/dotnet and omnisharp-server-executable-path to ...OmniSharp.dll - This start-process parameter breaks Mono compability