### PR TITLE
Reflect the problem with x64 omnisharp-roslyn server binary on windows and suggest a solution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Extract binary from [omnisharp-roslyn releases page](https://github.com/OmniShar
 ### On Windows (non-Cygwin)
 Use binary from [omnisharp-roslyn releases page](https://github.com/OmniSharp/omnisharp-roslyn/releases).
 
+*NOTE: For the moment you HAVE to use the `omnisharp-win-x86-net46.zip` bundle as -x64- one makes emacs
+to crash in `src/w32proc.c:w32_executable_type`.* See https://github.com/OmniSharp/omnisharp-emacs/issues/315
+
 Then you need to set the `omnisharp-server-executable-path` the path
 to where you have extracted server file, e.g.:
 


### PR DESCRIPTION
Sometimes emacs crashes on Windows when omnisharp-win-x64-net46.zip bundle is
used. The cause is detailed more thoroughly in
https://github.com/OmniSharp/omnisharp-emacs/issues/315.

Using x86 (32bit) binaries keeps emacs from crashing.

The actual fix will need to be submitted to emacs upstream.