### PR TITLE
Implement omnisharp-install-server (on macos and linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ You have three options here:
   * You can use M-x `omnisharp-install-server` to install omnisharp-server binary automatically. 
     * *NOTE: As of now this command works on Linux and macOS systems only. 
       Windows is planned but not implemented yet; -- see [omnisharp-emacs#275](https://github.com/OmniSharp/omnisharp-emacs/issues/275).*
+    * *NOTE 2*: This omnisharp server binary require [mono](http://www.mono-project.com/) to be installed on the system
+      (for macOS & Linux platforms only).
 
   * Download and extract server binaries
   manually and then point `omnisharp-server-executable-path` variable to the binary.

--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ the old omnisharp-server is no longer supported/maintained.
 
 ## Installation of the omnisharp-roslyn server application
 This emacs package requires the [omnisharp-roslyn][] server program.
-You can build the server yourself from the source or get precompiled 
-binaries from the [omnisharp-roslyn releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) page.
 
-The server must be a recent one, e.g. at least from year 2016.
-If you haven't updated your server copy since that, you must upgrade.
+You can use M-x `omnisharp-install-server` to install omnisharp-server binary locally
+into `~/.emacs.d/.cache/omnisharp/server/vX.Y.Z` or download and extract server binaries
+manually and then point `omnisharp-server-executable-path` variable to the binary.
 
-You can install the server from source as detailed on [omnisharp-roslyn building page](https://github.com/OmniSharp/omnisharp-roslyn#building). Or use the following instructions.
+ * NOTE: As of now the `omnisharp-install-server` command should work on Linux and macOS systems only. See [omnisharp-emacs#275](https://github.com/OmniSharp/omnisharp-emacs/issues/275).
 
- * TODO: there are plans to add automatic server installation/update mechanism to `omnisharp-emacs` eventually. See [omnisharp-emacs#275](https://github.com/OmniSharp/omnisharp-emacs/issues/275). But for now you have to install it manually.
+You can also build the server yourself from the source or get precompiled 
+binaries from the [omnisharp-roslyn releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) page. Building instructions for the server
+are detailed in [omnisharp-roslyn building page](https://github.com/OmniSharp/omnisharp-roslyn#building).
 
 ### On macOS with brew
 <pre>
@@ -40,7 +41,7 @@ Then you need to set the `omnisharp-server-executable-path`:
 (setq omnisharp-server-executable-path "/usr/local/bin/omnisharp")
 ```
 
-### On linux
+### On Linux
 Extract binary from [omnisharp-roslyn releases page](https://github.com/OmniSharp/omnisharp-roslyn/releases).
 
 ### On Windows (non-Cygwin)

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ the old omnisharp-server is no longer supported/maintained.
 ## Installation of the omnisharp-roslyn server application
 This emacs package requires the [omnisharp-roslyn][] server program.
 
-You can use M-x `omnisharp-install-server` to install omnisharp-server binary locally
-into `~/.emacs.d/.cache/omnisharp/server/vX.Y.Z` or download and extract server binaries
-manually and then point `omnisharp-server-executable-path` variable to the binary.
+You have three options here:
+  * You can use M-x `omnisharp-install-server` to install omnisharp-server binary automatically. 
+    * *NOTE: As of now this command works on Linux and macOS systems only. 
+      Windows is planned but not implemented yet; -- see [omnisharp-emacs#275](https://github.com/OmniSharp/omnisharp-emacs/issues/275).*
 
- * NOTE: As of now the `omnisharp-install-server` command should work on Linux and macOS systems only. See [omnisharp-emacs#275](https://github.com/OmniSharp/omnisharp-emacs/issues/275).
+  * Download and extract server binaries
+  manually and then point `omnisharp-server-executable-path` variable to the binary.
 
-You can also build the server yourself from the source or get precompiled 
-binaries from the [omnisharp-roslyn releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) page. Building instructions for the server
-are detailed in [omnisharp-roslyn building page](https://github.com/OmniSharp/omnisharp-roslyn#building).
+  * Build the server yourself from the source. Building instructions are detailed in [omnisharp-roslyn building page](https://github.com/OmniSharp/omnisharp-roslyn#building).
 
-### On macOS with brew
+### Manual installation on macOS with brew
 <pre>
 brew install omnisharp/omnisharp-roslyn/omnisharp-mono
 </pre>
@@ -41,10 +41,16 @@ Then you need to set the `omnisharp-server-executable-path`:
 (setq omnisharp-server-executable-path "/usr/local/bin/omnisharp")
 ```
 
-### On Linux
+### Manual installation on Linux
 Extract binary from [omnisharp-roslyn releases page](https://github.com/OmniSharp/omnisharp-roslyn/releases).
 
-### On Windows (non-Cygwin)
+Then you need to set the `omnisharp-server-executable-path`:
+
+```lisp
+(setq omnisharp-server-executable-path "<path-to-server-wrapper-script>")
+```
+
+### Manual installation on Windows (non-Cygwin)
 Use binary from [omnisharp-roslyn releases page](https://github.com/OmniSharp/omnisharp-roslyn/releases).
 
 *NOTE: For the moment you HAVE to use the `omnisharp-win-x86-net46.zip` bundle as -x64- one makes emacs
@@ -57,7 +63,7 @@ to where you have extracted server file, e.g.:
 (setq omnisharp-server-executable-path "C:\\Bin\\omnisharp-roslyn\\OmniSharp.exe")
 ```
 
-### On Windows (with Cygwin)
+### Manual installation on windows (with Cygwin)
 Use binary from [omnisharp-roslyn releases page](https://github.com/OmniSharp/omnisharp-roslyn/releases):
 
  - https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.9-beta22/omnisharp-win-x64-net46.zip

--- a/omnisharp-server-installation.el
+++ b/omnisharp-server-installation.el
@@ -1,0 +1,71 @@
+;; -*- lexical-binding: t -*-
+
+(defcustom omnisharp-expected-server-version "1.19.0"
+  "Version of the omnisharp-roslyn server that this omnisharp-emacs package
+is built for. Also used to select version for automatic server installation."
+  :group 'omnisharp
+  :type 'string)
+
+(defun omnisharp--server-installation-dir ()
+  "Returns installation directory for automatic server installation."
+  (f-join (expand-file-name "~") ".emacs.d" ".cache" "omnisharp" "server" (concat "v" omnisharp-expected-server-version)))
+
+(defun omnisharp--server-installation-path (&rest ok-if-missing)
+  "Returns path to installed omnisharp server binary, if any."
+  (let* ((executable-name "omnisharp") ;; TODO: platform dependant
+         (executable-path (f-join (omnisharp--server-installation-dir) executable-name)))
+    (if (or (f-exists-p executable-path) ok-if-missing)
+        executable-path
+      nil)))
+
+(defun omnisharp--server-installation-download-and-extract (url filename reinstall)
+  "Downloads and extracts a tgz binary into given directory."
+
+  ;; remove the file if reinstall is set
+  (if (and reinstall (f-exists-p filename))
+      (f-delete filename))
+
+  (unless (f-exists-p filename)
+    (message (format "omnisharp: downloading server binary from \"%s\"..." url))
+    (url-copy-file url filename t))
+
+  (message (format "omnisharp: extracting into %s" (f-dirname filename)))
+  (call-process "tar" nil nil t "xf" filename "-C" (f-dirname filename)))
+
+(defun omnisharp--server-installation-prepare-wrapper-script (filename server-dir)
+  (unless (f-exists-p filename)
+    (f-write (format "#!/usr/bin/env bash\nmono %s $@\n" (f-join server-dir "OmniSharp.exe"))
+             'utf-8
+             (f-join server-dir filename))
+    (call-process "chmod" nil nil nil "0755" (f-join server-dir filename))))
+
+(defun omnisharp--install-server (reinstall)
+  "Implementation for autoloaded omnisharp-install-server in omnisharp.el."
+  (let* ((server-dir (omnisharp--server-installation-dir))
+         (distro-tarball "omnisharp-mono.tar.gz") ;; TODO: platform specific
+         (distro-url (concat "https://github.com/OmniSharp/omnisharp-roslyn/releases/download"
+                             "/v" omnisharp-expected-server-version
+                             "/" distro-tarball))
+         (expected-executable-path (omnisharp--server-installation-path t)))
+    (if (or reinstall (not (f-exists-p expected-executable-path)))
+        (if (y-or-n-p (format "omnisharp: this will download and extract ~20-30 MB from \"%s\"; do you want to continue?"
+                              distro-url))
+            (progn
+              (message (format "omnisharp: attempting to download and install OmniSharp server into %s"
+                               server-dir))
+              (omnisharp--mkdirp server-dir)
+              (omnisharp--server-installation-download-and-extract
+               distro-url
+               (f-join server-dir distro-tarball)
+               reinstall)
+              (omnisharp--server-installation-prepare-wrapper-script "omnisharp" server-dir)
+              (let ((executable-path (omnisharp--server-installation-path)))
+                (if executable-path
+                    (message (format "omnisharp: server was installed to \"%s\"; you can now do M-x 'omnisharp-start-omnisharp-server' "
+                                     executable-path))
+                  (message (concat "omnisharp: server could not be installed automatically."
+                                   "Please check https://github.com/OmniSharp/omnisharp-emacs/blob/master/README.md#installation-of-the-omnisharp-roslyn-server-application for instructions."))))))
+      (message (format "omnisharp: server is already installed (%s)"
+                       expected-executable-path)))))
+
+(provide 'omnisharp-server-installation)

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -293,4 +293,19 @@ the developer's emacs unusable."
 `omnisharp--ido-completing-read' for the explanation."
   (apply 'read-string args))
 
+(defun omnisharp--mkdirp (dir)
+  "Makes a directory recursively, similarly to a 'mkdir -p'."
+  (let* ((absolute-dir (expand-file-name dir))
+         (components (f-split absolute-dir)))
+    (omnisharp--mkdirp-item (f-join (apply #'concat (-take 2 components))) (-drop 2 components))
+    absolute-dir))
+
+(defun omnisharp--mkdirp-item (dir remaining)
+  "Makes a directory if not exists,
+ and tries to do the same with the remaining components, recursively."
+  (unless (f-directory-p dir)
+    (f-mkdir dir))
+  (unless (not remaining)
+    (omnisharp--mkdirp-item (f-join dir (car (-take 1 remaining))) (-drop 1 remaining))))
+
 (provide 'omnisharp-utils)

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -4,7 +4,7 @@
 ;; Author: Mika Vilpas and others
 ;; Version: 4.0
 ;; Url: https://github.com/Omnisharp/omnisharp-emacs
-;; Package-Requires: ((emacs "24") (flycheck "30") (dash "2.12.0") (auto-complete "1.4") (popup "0.5.1") (csharp-mode "0.8.7") (cl-lib "0.5") (s "1.10.0") (shut-up "0.3.2"))
+;; Package-Requires: ((emacs "24") (flycheck "30") (dash "2.12.0") (auto-complete "1.4") (popup "0.5.1") (csharp-mode "0.8.7") (cl-lib "0.5") (s "1.10.0") (shut-up "0.3.2") (f "0.19.0"))
 ;; Keywords: languages csharp c# IDE auto-complete intellisense
 
 ;;; Commentary:
@@ -27,6 +27,7 @@
 (require 'flycheck)
 (require 's)
 (require 'shut-up)
+(require 'f)
 
 (require 'omnisharp-server-management)
 (require 'omnisharp-utils)
@@ -39,6 +40,7 @@
 (require 'omnisharp-helm-integration)
 (require 'omnisharp-solution-actions)
 (require 'omnisharp-format-actions)
+(require 'omnisharp-server-installation)
 
 ;;; Code:
 ;;;###autoload
@@ -110,6 +112,17 @@ OmniSharpServer process specified in the current configuration has
 finished loading the solution."
   (interactive)
   (omnisharp--check-ready-status))
+
+;;;###autoload
+(defun omnisharp-install-server (reinstall)
+  "Installs OmniSharp server locally into ~/.emacs/cache/omnisharp/server/$(version)"
+  (interactive "P")
+  (if (or (eq system-type 'darwin)
+          (eq system-type 'gnu/linux))
+      (omnisharp--install-server reinstall)
+    (message (format (concat "omnisharp: sorry, omnisharp-install-server does not support %s yet,"
+                             " please see https://github.com/OmniSharp/omnisharp-emacs/blob/master/README.md#installation-of-the-omnisharp-roslyn-server-application")
+                     system-type))))
 
 ;;;###autoload
 (defun company-omnisharp (command &optional arg &rest ignored)

--- a/test/buttercup-tests/setup.el
+++ b/test/buttercup-tests/setup.el
@@ -250,6 +250,7 @@ with one."
 ;; still sleep a bit because even with the input received the server
 ;; might still not be able to response to requests in-time for the
 ;; first test to run properly
+(print "waiting for the server to spin up (3 secs)..")
 (sleep-for 3)
 
 (setq create-lockfiles nil)


### PR DESCRIPTION
Experimental implementation of the command that attempts to download and install `omnisharp-mono.tgz` from omnisharp-roslyn releases page and extract to ~/.emacs.d/.cache/omnisharp/server/(version) directory.

Partially implements https://github.com/OmniSharp/omnisharp-emacs/issues/275

"Works-for-me" on macOS, needs testing, obviously.

And it also needs Windows implementation too.

