### PR TITLE
omnisharp-helm-integration.el: helm-highlight-current-line lost the pulse param

### DIFF
--- a/omnisharp-helm-integration.el
+++ b/omnisharp-helm-integration.el
@@ -36,7 +36,7 @@
 
   (defun omnisharp--helm-jump-to-candidate (json-result)
     (omnisharp-go-to-file-line-and-column json-result)
-    (helm-highlight-current-line nil nil nil nil t))
+    (helm-highlight-current-line))
 
   ;;; Helm find symbols
   (defun omnisharp-helm-find-symbols ()


### PR DESCRIPTION
Recent helm versions lost the `pulse` param on `helm-highlight-current-line`, an issue which triggers `wrong-number-arguments` errors for us now. Fix this