### PR TITLE
Fix request object to receive type documentation from a server

### DIFF
--- a/omnisharp-current-symbol-actions.el
+++ b/omnisharp-current-symbol-actions.el
@@ -22,7 +22,7 @@ from the server side, i.e. 'Type or 'Documentation that will be
 displayed to the user."
   (omnisharp--send-command-to-server
    "typelookup"
-   (omnisharp--get-request-object)
+   (omnisharp--get-typelookup-request-object)
    (lambda (response)
      (let ((stuff-to-display (cdr (assoc type-property-name
                                          response))))

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -331,6 +331,12 @@ some cases. Work around this."
               params)
       params)))
 
+(defun omnisharp--get-typelookup-request-object ()
+  "Construct a Request object for typelookup endpoint based on the current buffer contents."
+  (append
+   '((IncludeDocumentation . t))
+   (omnisharp--get-request-object)))
+
 (defun omnisharp--get-request-object-for-emacs-side-use ()
   "Gets a Request class that can be only handled safely inside
 Emacs. This should not be transferred to the server backend - it might


### PR DESCRIPTION
# Situation

`omnisharp-current-type-documentation` always show nothing.

# Problem

At `typelookup` request, we need to pass `IncludeDocumantation` parameter with `true` value, otherwise response's `Documentation` property is always `null`.

# Description of changes

New function `omnisharp--get-typelookup-request-object` was added to craete request object,
and `omnisharp-current-type-information-worker` uses it.

I think it's handy if we create `omnisharp--get-[ENDPOINT_NAME]-request-object` function for creating endpoints' specific request object.