### PR TITLE
omnisharp-install-server: implementation for Windows systems

### DIFF
--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -299,7 +299,7 @@ the developer's emacs unusable."
   "Makes a directory recursively, similarly to a 'mkdir -p'."
   (let* ((absolute-dir (expand-file-name dir))
          (components (f-split absolute-dir)))
-    (omnisharp--mkdirp-item (f-join (apply #'concat (-take 2 components))) (-drop 2 components))
+    (omnisharp--mkdirp-item (f-join (apply #'concat (-take 1 components))) (-drop 1 components))
     absolute-dir))
 
 (defun omnisharp--mkdirp-item (dir remaining)

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -117,12 +117,7 @@ finished loading the solution."
 (defun omnisharp-install-server (reinstall)
   "Installs OmniSharp server locally into ~/.emacs/cache/omnisharp/server/$(version)"
   (interactive "P")
-  (if (or (eq system-type 'darwin)
-          (eq system-type 'gnu/linux))
-      (omnisharp--install-server reinstall)
-    (message (format (concat "omnisharp: sorry, omnisharp-install-server does not support %s yet,"
-                             " please see https://github.com/OmniSharp/omnisharp-emacs/blob/master/README.md#installation-of-the-omnisharp-roslyn-server-application")
-                     system-type))))
+  (omnisharp--install-server reinstall))
 
 ;;;###autoload
 (defun company-omnisharp (command &optional arg &rest ignored)


### PR DESCRIPTION
NOTE: This requires PowerShell v5+ to be installed (i.e. base requirement is Windows 10+)

Part of #275