### PR TITLE
Add some specific display functions for easy override.

### DIFF
--- a/omnisharp-current-symbol-actions.el
+++ b/omnisharp-current-symbol-actions.el
@@ -26,9 +26,12 @@ displayed to the user."
    (lambda (response)
      (let ((stuff-to-display (cdr (assoc type-property-name
                                          response))))
-       (message stuff-to-display)
+       (omnisharp--display-type-information stuff-to-display)
        (when add-to-kill-ring
          (kill-new stuff-to-display))))))
+
+(defun omnisharp--display-type-information (stuff-to-display)
+  (omnisharp--display-stuff stuff-to-display))
 
 (defun omnisharp-current-type-information-to-kill-ring ()
   "Shows the information of the current type and adds it to the kill
@@ -48,7 +51,7 @@ ring."
 
 (defun omnisharp--find-usages-show-response (quickfixes)
   (if (equal 0 (length quickfixes))
-      (message "No usages found.")
+      (omnisharp--display-result-message "No usages found.")
     (omnisharp--write-quickfixes-to-compilation-buffer
      quickfixes
      omnisharp--find-usages-buffer-name
@@ -67,7 +70,7 @@ ring."
                                                            &optional other-window)
   (-let (((&alist 'QuickFixes quickfixes) quickfix-response))
     (cond ((equal 0 (length quickfixes))
-           (message "No implementations found."))
+           (omnisharp--display-result-message "No implementations found."))
           ((equal 1 (length quickfixes))
            (omnisharp-go-to-file-line-and-column (-first-item (omnisharp--vector-to-list quickfixes))
                                                  other-window))
@@ -93,7 +96,7 @@ to select one (or more) to jump to."
    (omnisharp--get-request-object)
    (lambda (quickfixes)
      (cond ((equal 0 (length quickfixes))
-            (message "No implementations found."))
+            (omnisharp--display-result-message "No implementations found."))
 
            ;; Go directly to the implementation if there only is one
            ((equal 1 (length quickfixes))

--- a/omnisharp-current-symbol-actions.el
+++ b/omnisharp-current-symbol-actions.el
@@ -12,7 +12,7 @@ to insert the result in code, for example."
 argument, add the displayed result to the kill ring. This can be used
 to insert the result in code, for example."
   (interactive "P")
-  (omnisharp-current-type-information-worker 'Documentation))
+  (omnisharp-current-type-information-worker 'Documentation add-to-kill-ring))
 
 (defun omnisharp-current-type-information-worker (type-property-name
                                                   &optional add-to-kill-ring)

--- a/omnisharp-solution-actions.el
+++ b/omnisharp-solution-actions.el
@@ -35,7 +35,7 @@ refactoring they want to run. Then runs the action."
                      (action-names (--map (cdr (assoc 'Name it))
                                           code-actions)))
                 (if (<= (length action-names) 0)
-                    (message "No refactorings available at this position.")
+                    (omnisharp--display-result-message "No refactorings available at this position.")
 
                   (let* ((chosen-action-name (omnisharp--ido-completing-read
                                               "Run code action: "

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -310,4 +310,10 @@ the developer's emacs unusable."
   (unless (not remaining)
     (omnisharp--mkdirp-item (f-join dir (car (-take 1 remaining))) (-drop 1 remaining))))
 
+(defun omnisharp--display-stuff (stuff-to-display)
+  (message stuff-to-display))
+
+(defun omnisharp--display-result-message (message)
+  (omnisharp--display-stuff message))
+
 (provide 'omnisharp-utils)


### PR DESCRIPTION
# Purpose

Make it easy to override "display" related behavior by user.

# Situation

Some actions shows the result using `message` function. If user want to change that behavior, he/she need to override entire function which call `message`.

# Changes

Added some display functions for common use in omnisharp-emacs.

- `omnisharp--display-stuff` for to display response object.
- `omnisharp--display-result-message` for to display result message of action.
  - Some actions use this to display the explanation text of action result.

Also added action-specific display function.

- `omnisharp--display-type-information` for `typelookup` related action.
  - `typelookup` action uses this to display a type information/documentation.

By default, behavior will not changes. When those function called, finally `message` function will be called. This changes doesn't break backward compatibility.

# Example use case

For example, when I call "at-point" behavior action, I want to display the result at just below of cursor. So I can override some functions as following.

```el
;; It requires popup.el package.

(defun omnisharp--display-type-information (stuff-to-display)
  (popup-tip stuff-to-display))

(defun omnisharp--display-result-message (message)
  (popup-tip message))
```

Then, I can get following result:

## `omnisharp-current-type-documentation`

![image](https://user-images.githubusercontent.com/377137/28513697-024942d6-7092-11e7-9bb9-5fd6957e18d3.png)

## `omnisharp-find-implementations` for Interface which is not implemented by any Class

![image](https://user-images.githubusercontent.com/377137/28513716-17a83560-7092-11e7-9b3d-d83951f88bcf.png)

Note that I'm not recommending every user to use popup.el like me.
This Pull Request just allows users to use their own favorite "displaying" function by easy way.