### PR TITLE
[WIP] Add some status check related functions

### DIFF
--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -14,6 +14,21 @@
     (:response-handlers . nil)
     (:started? . nil)))
 
+(defun omnisharp-server-running-p ()
+  "Returns t if omnisharp server is running. If not, it returns nil."
+  (not (equal nil omnisharp--server-info)))
+
+(defun omnisharp-file-in-current-project-p (file)
+  "Returns t if passed file is in the project which handled in current
+OmniSharp roslyn server process. If not, it returns nil."
+  (and omnisharp--last-project-path
+       (s-starts-with? omnisharp--last-project-path (expand-file-name file))))
+
+(defun omnisharp-buffer-file-in-current-project-p ()
+  "Returns t if current buffer's file is in the project which handled in current
+OmniSharp roslyn server process. If not, it returns nil."
+  (omnisharp-file-in-current-project-p (buffer-file-name)))
+
 (defun omnisharp--clear-response-handlers ()
   "For development time cleaning up impossible states of response
 handlers in the current omnisharp--server-info."


### PR DESCRIPTION
# Changes

Added following functions.

- `omnisharp-server-running-p`
- `omnisharp-file-in-current-project-p`
- `omnisharp-buffer-file-in-current-project-p`

# Purpose

Allow user to write hooks or functions which depends on server status.

## Example

Execute formatting automatically only if the server process is running and buffer file is part of project which handled by current server process.

```lisp
(defun my-omnisharp-after-save-hook ()
  (when (and (omnisharp-server-running-p) (omnisharp-buffer-file-in-current-project-p))
    (omnisharp-code-format-entire-file)))

(defun my-omnisharp-hook ()
  (add-hook 'before-save-hook 'my-omnisharp-after-save-hook nil t))

(add-hook 'omnisharp-mode-hook 'my-omnisharp-hook)
```