### PR TITLE
Remove needless macro omnisharp--setq-and-restore

### DIFF
--- a/omnisharp-auto-complete-actions.el
+++ b/omnisharp-auto-complete-actions.el
@@ -324,8 +324,7 @@ company-mode-friendly"
                    (omnisharp-auto-complete-worker
                     params
                     (lambda (result)
-                      (omnisharp--setq-and-restore
-                       completion-ignore-case omnisharp-company-ignore-case
+                      (let ((completion-ignore-case omnisharp-company-ignore-case))
                        (funcall cb (funcall handler result)))))))))
 
 (defun omnisharp--company-annotation (candidate)

--- a/omnisharp-server-actions.el
+++ b/omnisharp-server-actions.el
@@ -46,10 +46,8 @@ to use server installed via `omnisharp-install-server`.
   (setq omnisharp--server-info
         (make-omnisharp--server-info
          ;; use a pipe for the connection instead of a pty
-         (omnisharp--setq-and-restore
-          process-connection-type nil
-
-          (-doto (start-process
+         (let ((process-connection-type nil))
+	   (-doto (start-process
                   "OmniServer" ; process name
                   "OmniServer" ; buffer name
                   server-executable-path

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -324,17 +324,4 @@ the developer's emacs unusable."
   (unless (not remaining)
     (omnisharp--mkdirp-item (f-join dir (car (-take 1 remaining))) (-drop 1 remaining))))
 
-(defmacro omnisharp--setq-and-restore (var value &rest body)
-  "Sets a variable and restores it to original value on unwind.
-Used in places where lexical binding is not what we want.
-
-TODO: there might be an easier way to do this but I couldn't find
-      something like this that works with lexical-binding: t;"
-  `(let ((orig-value ,var))
-     (unwind-protect
-         (progn
-           (setq ,var ,value)
-           (progn ,@body))
-       (setq ,var orig-value))))
-
 (provide 'omnisharp-utils)


### PR DESCRIPTION
Use dynamic binding instead which is still in effect when using defvar
(process-connection-type and completion-ignore-case variables).

Refs #354