### PR TITLE
Bring back .sln and .csproj file discovery

### DIFF
--- a/omnisharp-server-actions.el
+++ b/omnisharp-server-actions.el
@@ -31,46 +31,55 @@ to use server installed via `omnisharp-install-server`.
                              " as detailed in https://github.com/OmniSharp/omnisharp-emacs/blob/master/doc/server-installation.md"))
             nil)))))
 
-(defun omnisharp--do-server-start (path-to-project server-executable-path)
-  (message (format "omnisharp: Starting OmniSharpServer using project folder/solution file: %s" path-to-project))
-  (message "omnisharp: using the server at: %s" server-executable-path)
-
-  ;; Save all csharp buffers to ensure the server is in sync"
-  (save-some-buffers t (lambda () (string-equal (file-name-extension (buffer-file-name)) "cs")))
-
-  (setq omnisharp--last-project-path path-to-project)
-
-  ;; this can be set by omnisharp-reload-solution to t
-  (setq omnisharp--restart-server-on-stop nil)
-
-  (setq omnisharp--server-info
-        (make-omnisharp--server-info
-         ;; use a pipe for the connection instead of a pty
-         (let ((process-connection-type nil))
-	   (-doto (start-process
-                  "OmniServer" ; process name
-                  "OmniServer" ; buffer name
-                  server-executable-path
-                  "--stdio" "-s" (omnisharp--path-to-server (expand-file-name path-to-project)))
-            (lambda (process) (buffer-disable-undo (process-buffer process)))
-            (set-process-filter 'omnisharp--handle-server-message)
-            (set-process-sentinel (lambda (process event)
-                                    (when (memq (process-status process) '(exit signal))
-                                      (message "omnisharp: OmniSharp server terminated")
-                                      (setq omnisharp--server-info nil)
-                                      (if omnisharp--restart-server-on-stop
-                                          (omnisharp--do-server-start
-                                           omnisharp--last-project-path
-                                           server-executable-path))))))))))
-
-(defun omnisharp--start-omnisharp-server (path-to-project)
-  "Actual implementation for autoloaded omnisharp-start-omnisharp-server"
+(defun omnisharp--do-server-start (path-to-project)
   (let ((server-executable-path (omnisharp--resolve-omnisharp-server-executable-path)))
+    (message (format "omnisharp: Starting OmniSharpServer using project folder/solution file: %s"
+                     path-to-project))
+    (message "omnisharp: using the server at: %s" server-executable-path)
+
+    ;; Save all csharp buffers to ensure the server is in sync"
+    (save-some-buffers t (lambda () (string-equal (file-name-extension (buffer-file-name)) "cs")))
+
+    (setq omnisharp--last-project-path path-to-project)
+
+    ;; this can be set by omnisharp-reload-solution to t
+    (setq omnisharp--restart-server-on-stop nil)
+
+    (setq omnisharp--server-info
+          (make-omnisharp--server-info
+           ;; use a pipe for the connection instead of a pty
+           (let ((process-connection-type nil))
+             (-doto (start-process
+                     "OmniServer" ; process name
+                     "OmniServer" ; buffer name
+                     server-executable-path
+                     "--stdio" "-s" (omnisharp--path-to-server (expand-file-name path-to-project)))
+               (lambda (process) (buffer-disable-undo (process-buffer process)))
+               (set-process-filter 'omnisharp--handle-server-message)
+               (set-process-sentinel (lambda (process event)
+                                       (when (memq (process-status process) '(exit signal))
+                                         (message "omnisharp: OmniSharp server terminated")
+                                         (setq omnisharp--server-info nil)
+                                         (if omnisharp--restart-server-on-stop
+                                             (omnisharp--do-server-start omnisharp--last-project-path)))))))))))
+
+(defun omnisharp--start-omnisharp-server ()
+  "Actual implementation for autoloaded omnisharp-start-omnisharp-server.
+
+Will query user for a path to project/solution file to start the server with."
+  (let ((server-executable-path (omnisharp--resolve-omnisharp-server-executable-path))
+        (project-file-candidates (nreverse (omnisharp--resolve-solution-file-candidates))))
     (if server-executable-path
-        (if (or (file-directory-p path-to-project)
-                (file-exists-p path-to-project))
-            (omnisharp--do-server-start path-to-project server-executable-path)
-          (error (format "Path does not lead to a valid project folder or solution file path: %s" path-to-project))))))
+        (if (require 'helm-grep nil 'noerror)
+            (helm :sources (helm-build-sync-source "Omnisharp - Start Server"
+                             :candidates project-file-candidates
+                             :action 'omnisharp--do-server-start))
+          (let ((path-to-project (read-file-name
+                                  "Start OmniSharp for project or solution file: ")))
+            (if (file-exists-p path-to-project)
+                (omnisharp--do-server-start path-to-project)
+              (error (format "Path does not lead to a valid project folder or solution file path: %s"
+                             path-to-project))))))))
 
 (defun omnisharp--stop-server ()
   "Actual implementation for autoloaded omnisharp-stop-server"

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -228,14 +228,6 @@ moving point."
     "updatebuffer"
     (omnisharp--get-request-object))))
 
-;; this is actually used in tests only
-(defun omnisharp--create-test-server (omnisharp-emacs-root-path)
-  (condition-case nil
-      (kill-process "OmniServer")
-    (error nil))
-  (omnisharp-start-omnisharp-server (s-concat omnisharp-emacs-root-path
-                                              "/test/MinimalProject")))
-
 (defun omnisharp--update-files-with-text-changes (file-name text-changes)
   (let ((file (find-file (omnisharp--convert-backslashes-to-forward-slashes
                           file-name))))
@@ -321,6 +313,21 @@ the developer's emacs unusable."
   (unless (f-directory-p dir)
     (f-mkdir dir))
   (unless (not remaining)
-    (omnisharp--mkdirp-item (f-join dir (car (-take 1 remaining))) (-drop 1 remaining))))
+    (omnisharp--mkdirp-item (f-join dir (car (-take 1 remaining)))
+                            (-drop 1 remaining))))
+
+(defun omnisharp--resolve-solution-file-candidates ()
+  "Resolves a list of .csproj and .sln file candidates to be used
+for starting a server based on the current buffer."
+  (let ((dir (file-name-directory (or buffer-file-name "")))
+        (candidates nil))
+    (while (and dir (not (f-root-p dir)))
+      (setq candidates (append candidates
+                               (f-files dir (lambda (filename)
+                                              (string-match-p
+                                               "\\(\\.sln\\|\\.csproj\\)$"
+                                               filename)))))
+      (setq dir (f-parent dir)))
+    candidates))
 
 (provide 'omnisharp-utils)

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -95,10 +95,10 @@ server backend."
 ;;
 
 ;;;###autoload
-(defun omnisharp-start-omnisharp-server (path-to-project)
-  "Starts an OmniSharp server for a given path to a project file or a directory"
-  (interactive "GStart OmniSharp for project folder or solution file: ")
-  (omnisharp--start-omnisharp-server path-to-project))
+(defun omnisharp-start-omnisharp-server ()
+  "Starts an OmniSharp server for a given path to a project or solution file"
+  (interactive)
+  (omnisharp--start-omnisharp-server))
 
 ;;;###autoload
 (defun omnisharp-stop-server ()

--- a/test/buttercup-tests/setup.el
+++ b/test/buttercup-tests/setup.el
@@ -253,11 +253,16 @@ with one."
 
 ;; Test suite setup. Start a test server process that can be used by
 ;; all tests
+
 (defun omnisharp-start-test-server ()
   (interactive)
   (let ((omnisharp-server-executable-path (concat omnisharp-emacs-root-path
                                                   "/travis-stuff/omnisharp-roslyn/OmniSharp")))
-    (omnisharp--create-test-server omnisharp-emacs-root-path)))
+    (condition-case nil
+        (kill-process "OmniServer")
+      (error nil))
+    (omnisharp--do-server-start (s-concat omnisharp-emacs-root-path
+                                          "/test/MinimalProject"))))
 
 (omnisharp-start-test-server)
 


### PR DESCRIPTION
Will use helm for project file selection if available, otherwise - read-file-name

Closes #286 