### PR TITLE
Implement at-point message displaying feature by using popup.el

### DIFF
--- a/omnisharp-current-symbol-actions.el
+++ b/omnisharp-current-symbol-actions.el
@@ -52,7 +52,7 @@ ring."
 (defun omnisharp-find-usages ()
   "Find usages for the symbol under point"
   (interactive)
-  (omnisharp--message-at-point "Finding usages...")
+  (omnisharp--message "Finding usages...")
   (omnisharp--send-command-to-server
    "findusages"
    (omnisharp--get-request-object)

--- a/omnisharp-current-symbol-actions.el
+++ b/omnisharp-current-symbol-actions.el
@@ -39,7 +39,7 @@ displayed to the user."
    (lambda (response)
      (let ((stuff-to-display (cdr (assoc type-property-name
                                          response))))
-       (message stuff-to-display)
+       (omnisharp--message-at-point stuff-to-display)
        (when add-to-kill-ring
          (kill-new stuff-to-display))))))
 
@@ -52,7 +52,7 @@ ring."
 (defun omnisharp-find-usages ()
   "Find usages for the symbol under point"
   (interactive)
-  (message "Finding usages...")
+  (omnisharp--message-at-point "Finding usages...")
   (omnisharp--send-command-to-server
    "findusages"
    (omnisharp--get-request-object)
@@ -61,7 +61,7 @@ ring."
 
 (defun omnisharp--find-usages-show-response (quickfixes)
   (if (equal 0 (length quickfixes))
-      (message "No usages found.")
+      (omnisharp--message-at-point "No usages found.")
     (omnisharp--write-quickfixes-to-compilation-buffer
      quickfixes
      omnisharp--find-usages-buffer-name
@@ -80,7 +80,7 @@ ring."
                                                            &optional other-window)
   (-let (((&alist 'QuickFixes quickfixes) quickfix-response))
     (cond ((equal 0 (length quickfixes))
-           (message "No implementations found."))
+           (omnisharp--message "No implementations found."))
           ((equal 1 (length quickfixes))
            (omnisharp-go-to-file-line-and-column (-first-item (omnisharp--vector-to-list quickfixes))
                                                  other-window))
@@ -101,12 +101,12 @@ ring."
 point, or classes derived from the class under point. Allow the user
 to select one (or more) to jump to."
   (interactive)
-  (message "Finding implementations...")
+  (omnisharp--message "Finding implementations...")
   (omnisharp-find-implementations-worker
    (omnisharp--get-request-object)
    (lambda (quickfixes)
      (cond ((equal 0 (length quickfixes))
-            (message "No implementations found."))
+            (omnisharp--message "No implementations found."))
 
            ;; Go directly to the implementation if there only is one
            ((equal 1 (length quickfixes))
@@ -149,7 +149,7 @@ name to rename to, defaulting to the current name of the symbol."
 (defun omnisharp--rename-worker (rename-response
                                  location-before-rename)
   (-if-let (error-message (cdr (assoc 'ErrorMessage rename-response)))
-      (message error-message)
+      (omnisharp--message error-message)
     (-let (((&alist 'Changes modified-file-responses) rename-response))
       ;; The server will possibly update some files that are currently open.
       ;; Save all buffers to avoid conflicts / losing changes
@@ -161,7 +161,7 @@ name to rename to, defaulting to the current name of the symbol."
       ;; the user does not feel disoriented
       (omnisharp-go-to-file-line-and-column location-before-rename)
 
-      (message "Rename complete in files: \n%s"
+      (omnisharp--message "Rename complete in files: \n%s"
                (-interpose "\n" (--map (omnisharp--get-filename it)
                                        modified-file-responses))))))
 

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -353,4 +353,12 @@ for starting a server based on the current buffer."
   (or (boundp 'omnisharp--metadata-source)
       (s-starts-with-p "*omnisharp-metadata:" (buffer-name))))
 
+(defun omnisharp--message (text)
+  "Displays passed text using message function."
+  (message "%s" text))
+
+(defun omnisharp--message-at-point (text)
+  "Displays passed text at point using popup-tip function."
+  (popup-tip (format "%s" text)))
+
 (provide 'omnisharp-utils)

--- a/test/buttercup-tests/current-symbol/current-type-information-test.el
+++ b/test/buttercup-tests/current-symbol/current-type-information-test.el
@@ -3,7 +3,7 @@
 (describe "Current type information"
   (it "lists usages of the symbol under point"
     (ot--open-the-minimal-project-source-file "MyClassContainer.cs")
-    (spy-on 'message :and-call-through)
+    (spy-on 'omnisharp--message-at-point nil)
     (ot--buffer-contents-and-point-at-$
      "namespace minimal"
      "{"
@@ -11,4 +11,4 @@
      "}")
 
     (omnisharp--wait-until-request-completed (omnisharp-current-type-information))
-    (expect 'message :to-have-been-called-with "minimal.Target")))
+    (expect 'omnisharp--message-at-point :to-have-been-called-with "minimal.Target")))

--- a/test/find-usages-test.el
+++ b/test/find-usages-test.el
@@ -2,6 +2,7 @@
 
 (ert-deftest omnisharp--find-usages-show-response-doesnt-show-zero-quickfixes ()
   (with-mock
+    (mock (omnisharp--message-at-point "No usages found.") => "")
     (stub omnisharp--write-quickfixes-to-compilation-buffer =>
           (error "should not show usages when there are none"))
     (omnisharp--find-usages-show-response nil)))


### PR DESCRIPTION
# Purpose

Make it easy to override "display" related behavior by user.

# Situation

Current actions will show the result using `message` function, but omnisharp-emacs has some feature which related with at-point symbols, and it'll give better UX if the result is shows in target symbol's right below.


# Changes

Added two display functions for common use in omnisharp-emacs.

- `omnisharp--message` to display stuffs by using `message` function. This function is added just for easy overriding.
- `omnisharp--message-at-point` to display stuffs at right below of the cursor by using `popup-tip` function.

If user doesn't like default behavior of those functions, she/he can override it easily.

---

You can read detailed discussion about this Pull Request at #338 .