### PR TITLE
Use platform-specific tarballs when installing server on macos and linux

### DIFF
--- a/omnisharp-server-installation.el
+++ b/omnisharp-server-installation.el
@@ -20,7 +20,7 @@
 (defun omnisharp--server-installation-executable-name ()
   (if (eq system-type 'windows-nt)
       "OmniSharp.exe"
-    "omnisharp"))
+    "run"))
 
 (defun omnisharp--server-installation-path (&rest ok-if-missing)
   "Returns path to installed omnisharp server binary, if any."
@@ -46,49 +46,38 @@
                      (f-filename filename)
                      target-dir))
 
-    (if (eq system-type 'windows-nt)
-        ;; on windows, we attempt to use powershell v5+, available on Windows 10+
-        (let ((powershell-version (substring
-                                   (shell-command-to-string "powershell -command \"(Get-Host).Version.Major\"")
-                                   0 -1)))
-          (if (>= (string-to-number powershell-version) 5)
-            (call-process "powershell"
-                          nil
-                          nil
-                          nil
-                          "-command"
-                          (concat "add-type -assembly system.io.compression.filesystem;"
-                                  "[io.compression.zipfile]::ExtractToDirectory(\"" filename "\", \"" target-dir "\")"))
+    (cond
+     ((eq system-type 'windows-nt)
+      (;; on windows, we attempt to use powershell v5+, available on Windows 10+
+       (let ((powershell-version (substring
+                                  (shell-command-to-string "powershell -command \"(Get-Host).Version.Major\"")
+                                  0 -1)))
+         (if (>= (string-to-number powershell-version) 5)
+             (call-process "powershell"
+                           nil
+                           nil
+                           nil
+                           "-command"
+                           (concat "add-type -assembly system.io.compression.filesystem;"
+                                   "[io.compression.zipfile]::ExtractToDirectory(\"" filename "\", \"" target-dir "\")"))
 
-            (message (concat "omnisharp: for the 'M-x omnisharp-install-server' "
-                             " command to work on Windows you need to have powershell v5+ installed"))))
-      (progn
-        (call-process "tar" nil nil t "xf" filename "-C" target-dir)
+           (message (concat "omnisharp: for the 'M-x omnisharp-install-server' "
+                            " command to work on Windows you need to have powershell v5+ installed"))))))
 
-        ;; setup wrapper script on unix platforms
-        (let ((server-exe (omnisharp--server-installation-executable-name)))
-          (unless (f-exists-p server-exe)
-            (f-write (format (concat "#!/usr/bin/env bash\n"
-                                     "MONO_ON_MACOS=\"/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono\"\n"
-                                     "if [[ -x \"$MONO_ON_MACOS\" ]]; then\n"
-                                     "    # mono may not be on $PATH on macOS, give it a helping hand\n"
-                                     "    MONO=\"$MONO_ON_MACOS\"\n"
-                                     "else\n"
-                                     "    # otherwise, we expect mono to be on $PATH\n"
-                                     "    MONO=mono\n"
-                                     "fi\n"
-                                     "$MONO " (f-join target-dir "OmniSharp.exe") " \"$@\"\n"))
-                     'utf-8
-                     (f-join target-dir server-exe))
-            (set-file-modes (f-join target-dir server-exe) #o755)))))))
+     ((or (eq system-type 'gnu/linux)
+          (eq system-type 'darwin))
+      (call-process "tar" nil nil t "xf" filename "-C" target-dir))
+
+     (t (signal "omnisharp-install-server does not support platform %s (yet)" system-type)))))
 
 (defun omnisharp--server-installation-tarball-name ()
   "Resolves a tarball or zip file to use for this installation.
 Note that due to a bug in emacs on Windows we currently use the x86/32bit version.
 See https://github.com/OmniSharp/omnisharp-emacs/issues/315"
-  (if (eq system-type 'windows-nt)
-      "omnisharp-win-x86-net46.zip"
-    "omnisharp-mono.tar.gz"))
+  (cond ((eq system-type 'windows-nt) "omnisharp-win-x86-net46.zip")
+        ((eq system-type 'darwin) "omnisharp-osx.tar.gz")
+        ((eq system-type 'gnu/linux) "omnisharp-linux-x64.tar.gz")
+        (t "omnisharp-mono.tar.gz")))
 
 (defun omnisharp--install-server (reinstall)
   "Implementation for autoloaded omnisharp-install-server in omnisharp.el."
@@ -111,7 +100,7 @@ See https://github.com/OmniSharp/omnisharp-emacs/issues/315"
                reinstall)
               (let ((executable-path (omnisharp--server-installation-path)))
                 (if executable-path
-                    (message (format "omnisharp: server was installed to \"%s\"; you can now do M-x 'omnisharp-start-omnisharp-server' "
+                    (message (format "omnisharp: server was installed as \"%s\"; you can now do M-x 'omnisharp-start-omnisharp-server' "
                                      executable-path))
                   (message (concat "omnisharp: server could not be installed automatically. "
                                    "Please check https://github.com/OmniSharp/omnisharp-emacs/blob/master/doc/server-installation.md for instructions."))))))

--- a/omnisharp-settings.el
+++ b/omnisharp-settings.el
@@ -82,7 +82,7 @@ Otherwise omnisharp request the user to do M-x `omnisharp-install-server` and th
 executable will be used instead."
   :type '(choice (const :tag "Not Set" nil) string))
 
-(defcustom omnisharp-expected-server-version "1.22.0"
+(defcustom omnisharp-expected-server-version "1.24.0"
   "Version of the omnisharp-roslyn server that this omnisharp-emacs package
 is built for. Also used to select version for automatic server installation."
   :group 'omnisharp


### PR DESCRIPTION
This lets us drop dependency on mono as it is bundled with platform-specific binaries already.

Closes #373 
Part of #275