### PR TITLE
Don't force ido when using completing-read

### DIFF
--- a/omnisharp-auto-complete-actions.el
+++ b/omnisharp-auto-complete-actions.el
@@ -490,10 +490,10 @@ is a more sophisticated matching framework than what popup.el offers."
            ;; This is only the display text. The text to be inserted
            ;; in the buffer will be fetched with this
            ;;
-           ;; TODO does ido-completing-read allow a custom format that
+           ;; TODO does completing-read allow a custom format that
            ;; could store these, as with popup-make-item ?
            (user-chosen-display-text
-            (omnisharp--ido-completing-read
+            (omnisharp--completing-read
              "Complete: "
              display-texts))
 

--- a/omnisharp-navigation-actions.el
+++ b/omnisharp-navigation-actions.el
@@ -121,7 +121,7 @@ selected member. With prefix argument, use another window."
 (defun omnisharp--choose-and-go-to-quickfix-ido
   (quickfixes &optional other-window)
   "Given a list of QuickFixes in list format (not JSON), displays them
-in an ido-completing-read prompt and jumps to the chosen one's
+in an completing-read prompt and jumps to the chosen one's
 Location.
 
 If OTHER-WINDOW is given, will jump to the result in another window."
@@ -133,7 +133,7 @@ If OTHER-WINDOW is given, will jump to the result in another window."
 
 (defun omnisharp--choose-quickfix-ido (quickfixes)
   "Given a list of QuickFixes, lets the user choose one using
-ido-completing-read. Returns the chosen element."
+completing-read. Returns the chosen element."
   ;; Ido cannot navigate non-unique items reliably. It either gets
   ;; stuck, or results in that we cannot reliably determine the index
   ;; of the item. Work around this by prepending the index of all items
@@ -149,7 +149,7 @@ ido-completing-read. Returns the chosen element."
            quickfixes))
 
          (chosen-quickfix-text
-          (omnisharp--ido-completing-read
+          (omnisharp--completing-read
            "Go to: "
            ;; TODO use a hashmap if too slow.
            ;; This algorithm is two iterations in the worst case

--- a/omnisharp-solution-actions.el
+++ b/omnisharp-solution-actions.el
@@ -51,7 +51,7 @@ refactoring they want to run. Then runs the action."
                 (if (<= (length action-names) 0)
                     (message "No refactorings available at this position.")
 
-                  (let* ((chosen-action-name (omnisharp--ido-completing-read
+                  (let* ((chosen-action-name (omnisharp--completing-read
                                               "Run code action: "
                                               action-names))
                          (chosen-action

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -295,16 +295,16 @@ changes to be applied to that buffer instead."
       (accept-process-output process 0.1)))
   request-id)
 
-(defun omnisharp--ido-completing-read (&rest args)
-  "Mockable wrapper for ido-completing-read.
-The problem with mocking ido-completing-read directly is that
+(defun omnisharp--completing-read (&rest args)
+  "Mockable wrapper for completing-read.
+The problem with mocking completing-read directly is that
 sometimes the mocks are not removed when an error occurs. This renders
 the developer's emacs unusable."
-  (apply 'ido-completing-read args))
+  (apply 'completing-read args))
 
 (defun omnisharp--read-string (&rest args)
   "Mockable wrapper for read-string, see
-`omnisharp--ido-completing-read' for the explanation."
+`omnisharp--completing-read' for the explanation."
   (apply 'read-string args))
 
 (defun omnisharp--mkdirp (dir)

--- a/test/buttercup-tests/current-symbol/find-implementations-with-ido-test.el
+++ b/test/buttercup-tests/current-symbol/find-implementations-with-ido-test.el
@@ -2,7 +2,8 @@
 
 (describe "Find implementations with ido"
   (before-each
-    (ot--open-the-minimal-project-source-file "MyClassContainer.cs"))
+    (ot--open-the-minimal-project-source-file "MyClassContainer.cs")
+    (spy-on completing-read-function))
 
   (it "navigates to the only implementation when only one found"
     (ot--buffer-contents-and-point-at-$
@@ -10,7 +11,8 @@
      "public class SomeClass : IInterface {}")
 
     (ot--evaluate-and-wait-for-server-response "(omnisharp-find-implementations-with-ido)")
-    (ot--point-should-be-on-a-line-containing "public class SomeClass : IInterface {}"))
+    (ot--point-should-be-on-a-line-containing "public class SomeClass : IInterface {}")
+    (expect completing-read-function :not :to-have-been-called))
 
   (it "lets the user choose one with ido when more than one found"
     (ot--buffer-contents-and-point-at-$
@@ -18,9 +20,5 @@
      "public class SomeClass : IInterface {}"
      "public class SomeClass2 : IInterface {}")
 
-    (ot--keyboard-input
-     (ot--meta-x-command "omnisharp-find-implementations-with-ido")
-     ;; choose the first item
-     (ot--press-key "RET"))
-
-    (ot--point-should-be-on-a-line-containing "public class SomeClass : IInterface {}")))
+    (ot--evaluate-and-wait-for-server-response "(omnisharp-find-implementations-with-ido)")
+    (expect completing-read-function :to-have-been-called)))

--- a/test/buttercup-tests/current-symbol/find-usages-with-ido-test.el
+++ b/test/buttercup-tests/current-symbol/find-usages-with-ido-test.el
@@ -15,7 +15,7 @@
      "    }"
      "}")
 
-    (ot--answer-omnisharp--ido-completing-read-with #'-first-item)
+    (ot--answer-omnisharp--completing-read-with #'-first-item)
 
     (omnisharp--wait-until-request-completed (omnisharp-find-usages-with-ido))
 

--- a/test/buttercup-tests/current-symbol/navigate-to-current-file-member-test.el
+++ b/test/buttercup-tests/current-symbol/navigate-to-current-file-member-test.el
@@ -17,7 +17,7 @@
 
     ;; automatically select the first candidate given to
     ;; omnisharp--choose-quickfix-ido.
-    (ot--answer-omnisharp--ido-completing-read-with #'-first-item)
+    (ot--answer-omnisharp--completing-read-with #'-first-item)
 
     (omnisharp--wait-until-request-completed
      (omnisharp-navigate-to-current-file-member))

--- a/test/buttercup-tests/navigation/find-symbols-test.el
+++ b/test/buttercup-tests/navigation/find-symbols-test.el
@@ -26,7 +26,7 @@
      "}")
     ;; automatically select the first candidate given to
     ;; omnisharp--choose-quickfix-ido.
-    (ot--answer-omnisharp--ido-completing-read-with
+    (ot--answer-omnisharp--completing-read-with
      (lambda (choices)
        (--first (s-contains? "MyClassContainer" it)
                 choices)))

--- a/test/buttercup-tests/navigation/navigate-to-region-test.el
+++ b/test/buttercup-tests/navigation/navigate-to-region-test.el
@@ -23,7 +23,7 @@
      "    #endregion awesome"
      "$"
      "}")
-    (ot--answer-omnisharp--ido-completing-read-with
+    (ot--answer-omnisharp--completing-read-with
      (lambda (choices)
        (--first (s-contains? "awesome" it)
                 choices)))

--- a/test/buttercup-tests/navigation/navigate-to-solution-file-test.el
+++ b/test/buttercup-tests/navigation/navigate-to-solution-file-test.el
@@ -18,7 +18,7 @@
     (-when-let (buffer (get-buffer "MyClass.cs"))
       (kill-buffer buffer))
 
-    (ot--answer-omnisharp--ido-completing-read-with
+    (ot--answer-omnisharp--completing-read-with
      (lambda (choices)
        (--first (s-contains? "MyClass.cs" it)
                 choices)))

--- a/test/buttercup-tests/setup.el
+++ b/test/buttercup-tests/setup.el
@@ -224,15 +224,15 @@ detecting situations in the middle of input is impossible."
 (defmacro ot--set (symbol value)
   `(setq symbol ,value))
 
-(defmacro ot--answer-omnisharp--ido-completing-read-with (answer-function)
+(defmacro ot--answer-omnisharp--completing-read-with (answer-function)
   "Automatically select the first candidate given to
-omnisharp--ido-completing-read. This could be done by controlling
+omnisharp--completing-read. This could be done by controlling
 ido with the keyboard like in other tests, but ido is not easy to
 control programmatically.
 
 ANSWER-FUNCTION should receive a list of choices (strings) and respond
 with one."
-  `(spy-on 'omnisharp--ido-completing-read :and-call-fake
+  `(spy-on 'omnisharp--completing-read :and-call-fake
            (lambda (_prompt _quickfixes)
              (funcall ,answer-function _quickfixes))))
 

--- a/test/buttercup-tests/solution/code-actions/fix-code-issue-test.el
+++ b/test/buttercup-tests/solution/code-actions/fix-code-issue-test.el
@@ -13,7 +13,7 @@
      "        Gu$id.NewGuid();"
      "    }"
      "}")
-    (ot--answer-omnisharp--ido-completing-read-with (lambda (choices) "using System;"))
+    (ot--answer-omnisharp--completing-read-with (lambda (choices) "using System;"))
     (omnisharp--wait-until-request-completed (omnisharp-run-code-action-refactoring))
     (ot--buffer-should-contain "using System;"))
 
@@ -28,7 +28,7 @@
      "    }"
      "}")
 
-    (ot--answer-omnisharp--ido-completing-read-with
+    (ot--answer-omnisharp--completing-read-with
      (lambda (choices)
        (--first (s-contains? "Extract Method" it)
                 choices)))
@@ -65,7 +65,7 @@
      "        }"
      "    }"
      "}")
-    (ot--answer-omnisharp--ido-completing-read-with
+    (ot--answer-omnisharp--completing-read-with
      (lambda (choices)
        (--first (equal it
                        "Generate class for 'MyNewClass' in 'MyNamespace' (in new file)")


### PR DESCRIPTION
If a user wants ido completion, he can set
`completing-read-function`. But we should not force ido as other users
might prefer alternatives such as helm and ivy (which set
`completing-read-function`).