### PR TITLE
Fix format of commands sent to stdin server

### DIFF
--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -134,6 +134,9 @@ sending."
   (if (equal nil omnisharp--server-info)
       (message (concat "omnisharp: OmniSharp server not running. "
                        "Start it with `omnisharp-start-omnisharp-server' first"))
+    (if (not (s-starts-with? "/" api-name))
+        (setq api-name (concat "/" api-name)))
+
     (-let* ((server-info omnisharp--server-info)
             ((&alist :process process
                      :request-id request-id) server-info)


### PR DESCRIPTION
It appears that the current versions of omnisharp-roslyn require that a command
is prefixed with
`/` (https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Abstractions/OmniSharpEndpoints.cs#L3)
and, indeed, without the prefix present omnisharp-emacs fails on each command
with the `NotSupportedException` exception thrown on each request.

This commit makes sure that the prefix is present.