### PR TITLE
WIP: Prefix Commands with '/' in stdio mode

### DIFF
--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -169,7 +169,7 @@ request responded by the server."
 
 (defun omnisharp--make-request-packet (api-name contents request-id)
   (-concat `((Arguments . ,contents))
-           `((Command . ,api-name)
+           `((Command . ,(concat "/" api-name))
              (Seq . ,request-id))))
 
 (defun omnisharp--handle-server-message (process message-part)


### PR DESCRIPTION
omnisharp-roslyn 1.25 doesn't understand commands without the / prefix.

Can anyone else confirm?

Perhaps it would be better to change the endpoint names in place?

TODO:
- [ ] update tests