### PR TITLE
fix wrong-number-of-arguments in omnisharp-rename response

### DIFF
--- a/omnisharp-current-symbol-actions.el
+++ b/omnisharp-current-symbol-actions.el
@@ -161,9 +161,10 @@ name to rename to, defaulting to the current name of the symbol."
       ;; the user does not feel disoriented
       (omnisharp-go-to-file-line-and-column location-before-rename)
 
-      (omnisharp--message "Rename complete in files: \n%s"
+      (omnisharp--message
+       (format "Rename complete in files: \n%s"
                (-interpose "\n" (--map (omnisharp--get-filename it)
-                                       modified-file-responses))))))
+                                       modified-file-responses)))))))
 
 (defun omnisharp--apply-text-changes (modified-file-response)
   (-let (((&alist 'Changes changes) modified-file-response))


### PR DESCRIPTION
This fixes an error when omnisharp-rename succeeds.  It was after the rename completed and got eaten by the general reponse error handling, then printed to the omnisharp log.

Should we fail tests when any errors are written to the log?  I guess we'd need to change https://github.com/OmniSharp/omnisharp-emacs/blob/906e29a702237f039f24c215fdb561a728a3df1b/omnisharp-server-management.el#L297 to indicate an error.