### PR TITLE
install without restarting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See:
 
 ### Installation on Spacemacs
 Add `csharp` layer to `dotspacemacs-configuration-layers` on your `.spacemacs`
-file and restart emacs. `csharp-mode` and `omnisharp` packages will get
+file and restart Emacs. `csharp-mode` and `omnisharp` packages will get
 installed automatically for you on restart.
 
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ See:
 
 ### Installation on Spacemacs
 Add `csharp` layer to `dotspacemacs-configuration-layers` on your `.spacemacs`
-file and restart Emacs. `csharp-mode` and `omnisharp` packages will get
-installed automatically for you on restart.
+file and restart Emacs or run `dotspacemacs/sync-configuration-layers` (`SPC f e R`
+in evil mode, `M-m f e R` in Emacs mode).
+`csharp-mode` and `omnisharp` packages will get installed automatically for you on restart.
 
 
 ### Installation on Regular Emacs


### PR DESCRIPTION
The readme file suggests to restart Emacs to make the addition of the layer effective.

Actually, instead of restarting Emacs one could just hit `SPC f e R` or `M-m f e E", which correspond to `dotspacemacs/sync-configuration-layers` to make Emacs reload its configuration file.

The PR adds this information to the readme.