### PR TITLE
(POC) Run all tests in class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /test/MinimalProject/obj/*
 /test/MinimalProject/KeystrokeTest.cs
 *~
+*.elc

--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -131,11 +131,7 @@ The variable ASYNC has no effect when not using http."
   (-let* ((server-info omnisharp--server-info))
     (setcdr (assoc :event-handlers server-info)
       (-concat `((,event-name . ,event-handler))
-        (cdr (assoc :event-handlers server-info))
-        )
-      )
-    )
-  )
+        (cdr (assoc :event-handlers server-info))))))
 
 (defun omnisharp--unregister-server-event-handler (event-name)
   (-let* ((server-info omnisharp--server-info))

--- a/omnisharp-settings.el
+++ b/omnisharp-settings.el
@@ -32,7 +32,7 @@ instance that works in the background."
   "The name of the temporary buffer that is used to display the
 results of a 'find usages' call.")
 
-(defvar omnisharp--test-results-buffer-name "* Omnisharp : Test Results *"
+(defvar omnisharp--unit-test-results-buffer-name "* Omnisharp : Unit Test Results *"
   "The name of the temporary buffer that is used to display the results
 of a 'run tests' call.")
 

--- a/omnisharp-settings.el
+++ b/omnisharp-settings.el
@@ -32,6 +32,10 @@ instance that works in the background."
   "The name of the temporary buffer that is used to display the
 results of a 'find usages' call.")
 
+(defvar omnisharp--test-results-buffer-name "* Omnisharp : Test Results *"
+  "The name of the temporary buffer that is used to display the results
+of a 'run tests' call.")
+
 (defvar omnisharp-debug nil
   "When non-nil, omnisharp-emacs will write entries a debug log")
 

--- a/omnisharp-test-actions.el
+++ b/omnisharp-test-actions.el
@@ -1,0 +1,98 @@
+;; -*- lexical-binding: t -*-
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(defun omnisharp--run-all-tests-in-class ()
+  (interactive)
+  (omnisharp--current-buffer-project
+    (lambda (project-framework)
+      (omnisharp--current-file-members-as-tree
+        (lambda (file-members)
+          (if
+            (or
+              (equal nil file-members)
+              (equal 0 (length file-members)))
+            (message "omnisharp: No Test Methods to run")
+            (let* (
+                    (raw-test-type (alist-get 'Name (-first-item file-members)))
+                    (test-method-names (-map (lambda (d) (alist-get 'Data d)) file-members))
+                    (test-type (cdr (assoc raw-test-type '(
+                                                       ("XunitTestMethod" . "xunit")
+                                                       ("MSTestMethod" . "mstest")
+                                                       ("NunitTestMethod" . "nunit")
+                                                       ))))
+                    (request-message (-concat
+                                       (omnisharp--get-request-object)
+                                       `((TestFrameworkName . ,test-type)
+                                          (TargetFrameworkVersion . ,project-framework)
+                                          (MethodNames . ,(vconcat test-method-names))
+                                          )
+                                     )
+                      ))
+              ;;(message (json-encode request-message))
+              (omnisharp--send-command-to-server "/v2/runtestsinclass"
+                request-message
+                (lambda (resp) (message "%s" resp))
+                )
+
+
+              ))))
+      ))
+  )
+
+(defun omnisharp--get-class-declarations-from-response (response)
+  (-filter (lambda (x)
+             (equal "ClassDeclaration" (alist-get 'Kind x)))
+           (omnisharp--vector-to-list (alist-get 'TopLevelTypeDefinitions response))))
+
+(defun omnisharp--get-test-info-for-class (classes)
+  (-map
+    (-lambda (info) info)
+    (omnisharp--vector-to-list
+      (-mapcat
+        (lambda (x3) (alist-get 'Features x3))
+        (-filter
+          (lambda (x2) (equal "MethodDeclaration" (alist-get 'Kind x2)))
+          (-mapcat
+            (lambda (x1) (omnisharp--vector-to-list (alist-get 'ChildNodes x1)))
+            classes)
+          )))
+    )
+  )
+
+(defun omnisharp--current-file-members-as-tree (callback)
+  (omnisharp--send-command-to-server-sync
+    "/currentfilemembersastree"
+    (omnisharp--get-request-object)
+    (-lambda (response)
+      (funcall callback (omnisharp--get-test-info-for-class
+                          (omnisharp--get-class-declarations-from-response
+                            response)))))
+  )
+
+(defun omnisharp--current-buffer-project (callback)
+  (omnisharp--send-command-to-server
+    "/project"
+    (omnisharp--get-request-object)
+    (lambda (response)
+      (funcall callback (omnisharp--get-project-framework response)
+        )))
+  )
+
+(defun omnisharp--get-project-framework (response)
+  (alist-get 'TargetFramework (alist-get 'MsBuildProject response))
+  )
+
+
+(provide 'omnisharp-test-actions)

--- a/omnisharp-test-actions.el
+++ b/omnisharp-test-actions.el
@@ -46,7 +46,7 @@
               (omnisharp--send-command-to-server "/v2/runtestsinclass"
                 request-message
                 (lambda (resp)
-                  (message "%s" resp)
+                  ;;(message "%s" resp)
                   (omnisharp--unregister-server-event-handler "TestMessage")
                 )
               ))))
@@ -102,18 +102,19 @@
            (omnisharp--vector-to-list (alist-get 'TopLevelTypeDefinitions response))))
 
 (defun omnisharp--get-test-info-for-class (classes)
-  (-map
-    (-lambda (info) info)
-    (omnisharp--vector-to-list
-      (-mapcat
-        (lambda (x3) (alist-get 'Features x3))
-        (-filter
-          (lambda (x2) (equal "MethodDeclaration" (alist-get 'Kind x2)))
-          (-mapcat
-            (lambda (x1) (omnisharp--vector-to-list (alist-get 'ChildNodes x1)))
-            classes)
-          )))
-    )
+  (omnisharp--vector-to-list
+    (-mapcat
+      (lambda (x3) (omnisharp--vector-to-list (alist-get 'Features x3)))
+      (-filter 'omnisharp--is-test-method?
+        (-mapcat
+          (lambda (x1) (omnisharp--vector-to-list (alist-get 'ChildNodes x1)))
+          classes)
+        )))
+  )
+
+(defun omnisharp--is-test-method? (node)
+  (and (equal "MethodDeclaration" (alist-get 'Kind node))
+    (< 0 (length (alist-get 'Features node))))
   )
 
 (defun omnisharp--current-file-members-as-tree (callback)

--- a/omnisharp-test-actions.el
+++ b/omnisharp-test-actions.el
@@ -40,6 +40,7 @@
                                           )
                                      )
                       ))
+              (omnisharp--prepare-test-result-buffer)
               (omnisharp--register-server-event-handler "TestMessage" 'omnisharp--handle-test-message-event)
               ;;(message (json-encode request-message))
               (omnisharp--send-command-to-server "/v2/runtestsinclass"

--- a/omnisharp-test-actions.el
+++ b/omnisharp-test-actions.el
@@ -48,6 +48,7 @@
                 (lambda (resp)
                   ;;(message "%s" resp)
                   (omnisharp--unregister-server-event-handler "TestMessage")
+                  (display-buffer omnisharp--test-results-buffer-name)
                 )
               ))))
       ))

--- a/omnisharp-unit-test-actions.el
+++ b/omnisharp-unit-test-actions.el
@@ -13,7 +13,8 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(defun omnisharp--run-all-tests-in-class ()
+(defun omnisharp-unit-test-buffer ()
+  "Runs all test cases defined in the current buffer."
   (interactive)
   (omnisharp--current-buffer-project
     (lambda (project-framework)
@@ -23,14 +24,14 @@
             (or
               (equal nil file-members)
               (equal 0 (length file-members)))
-            (message "omnisharp: No Test Methods to run")
+            (omnisharp--message "omnisharp: No Test Methods to run")
             (let* (
                     (raw-test-type (alist-get 'Name (-first-item file-members)))
                     (test-method-names (-map (lambda (d) (alist-get 'Data d)) file-members))
                     (test-type (cdr (assoc raw-test-type '(
                                                        ("XunitTestMethod" . "xunit")
                                                        ("MSTestMethod" . "mstest")
-                                                       ("NunitTestMethod" . "nunit")
+                                                       ("NUnitTestMethod" . "nunit")
                                                        ))))
                     (request-message (-concat
                                        (omnisharp--get-request-object)
@@ -40,44 +41,96 @@
                                           )
                                      )
                       ))
-              (omnisharp--prepare-test-result-buffer)
+              (omnisharp--unit-test-reset-test-results-buffer t)
               (omnisharp--register-server-event-handler "TestMessage" 'omnisharp--handle-test-message-event)
-              ;;(message (json-encode request-message))
               (omnisharp--send-command-to-server "/v2/runtestsinclass"
                 request-message
                 (lambda (resp)
-                  ;;(message "%s" resp)
                   (omnisharp--unregister-server-event-handler "TestMessage")
-                  (display-buffer omnisharp--test-results-buffer-name)
-                )
-              ))))
-      ))
-    )
-  )
+                  (-let (((&alist 'Results results
+                                  'Pass passed) resp))
+                    (omnisharp--unit-test-emit-results passed results))
+                  ))
+              )
+            ))))))
 
-(defun omnisharp--handle-test-message-event (message)
-  (-let* (
-           ((&alist 'Body body) message)
-           ((&alist 'Message log-message) body))
-    (let (
-           (existing-buffer (get-buffer omnisharp--test-results-buffer-name)))
-;;      (omnisharp--append-lines-to-compilation-buffer log-message existing-buffer)
-      (if existing-buffer
+(defun omnisharp--unit-test-emit-results (passed results)
+  "Emits unit test results as returned by the server to the unit test result buffer.
+PASSED is t if all of the results have passed. RESULTS is a vector of status data for
+each of the unit tests ran."
+  ; we want to clean output buffer for result if things have passed otherwise
+  ; compilation & test run output is to be cleared and results shown only for brevity
+
+  (omnisharp--unit-test-message "")
+
+  (seq-doseq (result results)
+    (-let* (((&alist 'MethodName method-name
+                     'Outcome outcome
+                     'ErrorMessage error-message
+                     'ErrorStackTrace error-stack-trace
+                     'StandardOutput stdout
+                     'StanderError stderr) result)
+            (outcome-is-passed (string-equal "passed" outcome)))
+
+      (omnisharp--unit-test-message
+       (format "[%s] %s "
+               (propertize
+                (upcase outcome)
+                'font-lock-face (if outcome-is-passed
+                                    '(:foreground "green" :weight bold)
+                                  '(:foreground "red" :weight bold)))
+               (omnisharp--truncate-symbol-name method-name 76)))
+
+      (unless outcome-is-passed
+        (omnisharp--unit-test-message error-message)
+
+        (if error-stack-trace
+            (omnisharp--unit-test-message error-stack-trace))
+
+        (unless (= (seq-length stdout) 0)
+            (omnisharp--unit-test-message "Standard output:")
+            (seq-doseq (stdout-line stdout)
+              (omnisharp--unit-test-message stdout-line)))
+
+        (unless (= (seq-length stderr) 0)
+            (omnisharp--unit-test-message "Standard error:")
+            (seq-doseq (stderr-line stderr)
+              (omnisharp--unit-test-message stderr-line)))
+        )))
+
+  (omnisharp--unit-test-message "")
+
+  (if (eq passed :json-false)
+      (omnisharp--unit-test-message
+       (propertize "*** UNIT TEST RUN HAS FAILED ***"
+                   'font-lock-face '(:foreground "red" :weight bold)))
+    (omnisharp--unit-test-message
+     (propertize "*** UNIT TEST RUN HAS SUCCEEDED ***"
+                 'font-lock-face '(:foreground "green" :weight bold)))
+    )
+  nil)
+
+(defun omnisharp--unit-test-message (message)
+  (let ((existing-buffer (get-buffer omnisharp--unit-test-results-buffer-name)))
+    (if existing-buffer
         (with-current-buffer existing-buffer
           (setq buffer-read-only nil)
           (goto-char (point-max))
-          (insert log-message)
+          (insert message)
           (insert "\n")
-          (setq buffer-read-only t)
-          )
-        )
-      )
-    )
-  )
+          (setq buffer-read-only t)))))
 
-(defun omnisharp--prepare-test-result-buffer ()
-  ""
-  (let ((existing-buffer (get-buffer omnisharp--test-results-buffer-name))
+(defun omnisharp--handle-test-message-event (message)
+  "This is hooked into omnisharp 'TestMessage event and when handling an
+event will emit any test action output to unit test output buffer."
+  (-let* (
+           ((&alist 'Body body) message)
+           ((&alist 'Message log-message) body))
+    (omnisharp--unit-test-message log-message)))
+
+(defun omnisharp--unit-test-reset-test-results-buffer (present-buffer)
+  "Creates new or reuses existing unit test result output buffer."
+  (let ((existing-buffer (get-buffer omnisharp--unit-test-results-buffer-name))
          (solution-root-dir (cdr (assoc :project-root omnisharp--server-info))))
     (if existing-buffer
       (progn
@@ -87,7 +140,7 @@
           (setq buffer-read-only t)
           (setq default-directory solution-root-dir))
         existing-buffer)
-      (let ((buffer (get-buffer-create omnisharp--test-results-buffer-name)))
+      (let ((buffer (get-buffer-create omnisharp--unit-test-results-buffer-name)))
         (with-current-buffer buffer
           (setq default-directory solution-root-dir)
           (compilation-mode)
@@ -95,7 +148,9 @@
         )
       )
     )
-  )
+
+  (if present-buffer
+      (display-buffer omnisharp--unit-test-results-buffer-name)))
 
 (defun omnisharp--get-class-declarations-from-response (response)
   (-filter (lambda (x)
@@ -125,8 +180,7 @@
     (-lambda (response)
       (funcall callback (omnisharp--get-test-info-for-class
                           (omnisharp--get-class-declarations-from-response
-                            response)))))
-  )
+                            response))))))
 
 (defun omnisharp--current-buffer-project (callback)
   (omnisharp--send-command-to-server
@@ -134,12 +188,11 @@
     (omnisharp--get-request-object)
     (lambda (response)
       (funcall callback (omnisharp--get-project-framework response)
-        )))
-  )
+        ))))
 
 (defun omnisharp--get-project-framework (response)
   (alist-get 'TargetFramework (alist-get 'MsBuildProject response))
   )
 
 
-(provide 'omnisharp-test-actions)
+(provide 'omnisharp-unit-test-actions)

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -89,6 +89,24 @@ recognizes, so that the user may jump to the results."
         (setq buffer-read-only t))
       (display-buffer buffer-to-write-to))))
 
+(defun omnisharp--append-lines-to-compilation-buffer
+  (lines-to-write buffer-to-write-to)
+  (with-current-buffer buffer-to-write-to
+    (goto-char (point-max))
+    ;; read-only-mode new in Emacs 24.3
+    (if (fboundp 'read-only-mode)
+      (read-only-mode nil)
+      (setq buffer-read-only nil))
+    (mapc (lambda (element)
+            (insert element)
+            (insert "\n"))
+      lines-to-write)
+    (compilation-mode)
+    (if (fboundp 'read-only-mode)
+      (read-only-mode t)
+      (setq buffer-read-only t))
+    (display-buffer buffer-to-write-to)))
+
 (defun omnisharp--find-usages-output-to-compilation-output
   (json-result-single-element)
   "Converts a single element of a /findusages JSON response to a

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -136,7 +136,7 @@ finished loading the solution."
 
 ;;;###autoload
 (defun omnisharp-install-server (reinstall)
-  "Installs OmniSharp server locally into ~/.emacs/cache/omnisharp/server/$(version)"
+  "Installs OmniSharp server locally into ~/.emacs/cache/omnisharp/server/$(tversion)"
   (interactive "P")
   (omnisharp--install-server reinstall))
 
@@ -616,6 +616,10 @@ cursor at that location"
 ;; nunit-console.exe on windows uses this format
 (add-to-list 'compilation-error-regexp-alist
              '(" in \\(.+\\):line \\([0-9]+\\)" 1 2))
+
+;; dotnet test with xunit project
+;; [xUnit.net 00:00:00.6080370]         /TestProject/UnitTest1.cs(15,0): at TestProject.UnitTest1.Test1()
+(add-to-list 'compilation-error-regexp-alist '("\\[xUnit.net .*\\] +\\(.*\\)(\\([[:digit:]]+\\),\\([[:digit:]]+\\))" 1 2 3))
 
 (provide 'omnisharp)
 

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -59,7 +59,7 @@
 (require 'omnisharp-solution-actions)
 (require 'omnisharp-format-actions)
 (require 'omnisharp-server-installation)
-(require 'omnisharp-test-actions)
+(require 'omnisharp-unit-test-actions)
 
 ;;; Code:
 ;;;###autoload
@@ -136,7 +136,7 @@ finished loading the solution."
 
 ;;;###autoload
 (defun omnisharp-install-server (reinstall)
-  "Installs OmniSharp server locally into ~/.emacs/cache/omnisharp/server/$(tversion)"
+  "Installs OmniSharp server locally into ~/.emacs/cache/omnisharp/server/$(version)"
   (interactive "P")
   (omnisharp--install-server reinstall))
 

--- a/omnisharp.el
+++ b/omnisharp.el
@@ -59,6 +59,7 @@
 (require 'omnisharp-solution-actions)
 (require 'omnisharp-format-actions)
 (require 'omnisharp-server-installation)
+(require 'omnisharp-test-actions)
 
 ;;; Code:
 ;;;###autoload


### PR DESCRIPTION
This is a in progress attempt to have omnisharp-emacs support run all tests in class ( why I picked this one who knows )

Currently this functionality actual works.   Tests are run and omnisharp returns back for following example message

`{"Request_seq":11,"Command":"/v2/runtestsinclass","Running":true,"Success":true,"Message":null,"Body":{"Results":[{"MethodName":"TestProject.UnitTest1.Test1","Outcome":"passed","ErrorMessage":null,"ErrorStackTrace":null}],"Pass":true,"Failure":null},"Seq":373,"Type":"response"}`

TODO
- [x] Need to figure out how to display the results and errors
_Using compilation buffer which the output from the test framework for example xunit_
```
Microsoft (R) Build Engine version 15.5.180.51428 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  TestProject -> /Users/alistair.bush/projects/TestProject/bin/Debug/netcoreapp2.0/TestProject.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.74


[xUnit.net 00:00:00.4129590]   Discovering: TestProject
[xUnit.net 00:00:00.4875360]   Discovered:  TestProject
[xUnit.net 00:00:00.4336950]   Starting:    TestProject
[xUnit.net 00:00:00.6051810]     TestProject.UnitTest1.Test1 [FAIL]
[xUnit.net 00:00:00.6063010]       Assert.True() Failure
[xUnit.net 00:00:00.6063630]       Expected: True
[xUnit.net 00:00:00.6063890]       Actual:   False
[xUnit.net 00:00:00.6074430]       Stack Trace:
[xUnit.net 00:00:00.6089270]         /Users/alistair.bush/projects/TestProject/UnitTest1.cs(11,0): at TestProject.UnitTest1.Test1()
[xUnit.net 00:00:00.6210890]   Finished:    TestProject
```
- [x] Update compilation buffer to be able to parse test output
- [x] Check if other test frameworks have the same output or not.  (support mstest and nunit)

- Current implementation for xunit uses the logs from omnisharp to display compilcation-buffer.  Therefore giving both compile + test run errors
- MSTest doesn't seem to give the same output :(

- [ ] Display test output buffer when running tests and clear output each run.
- [ ] Update compilcation buffer to catch compulation errors from dotnet build/test

Just wanted to get this out early so I can get feedback on it.

This is my first piece of lisp ive written so would love some constructive feedback on it.

This goes some way to solving #358