### PR TITLE
Increase omnisharp to 1.31.1 and increase startup time for tests

### DIFF
--- a/omnisharp-settings.el
+++ b/omnisharp-settings.el
@@ -87,7 +87,7 @@ Otherwise omnisharp request the user to do M-x `omnisharp-install-server` and th
 executable will be used instead."
   :type '(choice (const :tag "Not Set" nil) string))
 
-(defcustom omnisharp-expected-server-version "1.26.3"
+(defcustom omnisharp-expected-server-version "1.31.1"
   "Version of the omnisharp-roslyn server that this omnisharp-emacs package
 is built for. Also used to select version for automatic server installation."
   :group 'omnisharp

--- a/test/buttercup-tests/setup.el
+++ b/test/buttercup-tests/setup.el
@@ -270,8 +270,8 @@ with one."
 ;; still sleep a bit because even with the input received the server
 ;; might still not be able to response to requests in-time for the
 ;; first test to run properly
-(print "waiting for the server to spin up (3 secs)..")
-(sleep-for 3)
+(print "waiting for the server to spin up (10 secs)..")
+(sleep-for 10)
 
 (setq create-lockfiles nil)
 


### PR DESCRIPTION
Should be self explanatory.

It does seem like the server takes more time to startup and I haven't tested ALL functionality but I have  been using this version lightly as part of the other pull request.