### PR TITLE
actually sleep so omnisharp starts

### DIFF
--- a/test/buttercup-tests/setup.el
+++ b/test/buttercup-tests/setup.el
@@ -270,8 +270,21 @@ with one."
 ;; still sleep a bit because even with the input received the server
 ;; might still not be able to response to requests in-time for the
 ;; first test to run properly
-(print "waiting for the server to spin up (10 secs)..")
-(sleep-for 10)
+(print "waiting for the server to spin up (5 secs)..")
+(print (current-time-string))
+
+;; sleep-for doesn't work in some versions of emacs.  Using current-time-string
+;; to ensure from output that we are actually waiting for the server to started
+;; and using a hack to force wait which was from this link
+;; https://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-when-running-a-test-in-ert
+;;(sleep-for 10)
+(let ((now (float-time))
+       (process-connection-type nil))
+  (start-process "tmp" "*tmp*" "bash" "-c" "sleep 1; echo hi")
+  (while (< (- (float-time) now) 5)
+    (sleep-for 1))
+  )
+(print (current-time-string))
 
 (setq create-lockfiles nil)
 


### PR DESCRIPTION
Hi @razzmatazz 

Sorry but im pretty sure that my last pull request did break the tests.

 think ive identified this as being due to sleep-for not actually doing anything when we have async processing occurring ( aka from the omnisharp stdout response )

I would love 2 say this will fix it.   but i remember saying my last pr worked :|

I figured this out by making the sleep-for value really large,  like 60 seconds, and not noticing the docker build taking any longer.