### PR TITLE
Fix displaying list of overrides

### DIFF
--- a/omnisharp-auto-complete-actions.el
+++ b/omnisharp-auto-complete-actions.el
@@ -383,8 +383,8 @@ result."
   (save-excursion
     (end-of-thing 'symbol)
     (omnisharp-auto-complete-worker
-     (omnisharp--create-auto-complete-request))
-    (omnisharp-show-last-auto-complete-result)))
+     (omnisharp--create-auto-complete-request)
+     (lambda (_)(omnisharp-show-last-auto-complete-result)))))
 
 (defun omnisharp--auto-complete-display-function-popup
   (json-result-alist)


### PR DESCRIPTION
Hi,

I've started using `omnisharp-show-overloads-at-point`, but it shows results only for the second time I call it on the same member. The fix is to call `omnisharp-show-last-auto-complete-result` in a callback, rather than outside of it. 