### PR TITLE
New project solutions don't require adding files to solution

### DIFF
--- a/omnisharp-solution-actions.el
+++ b/omnisharp-solution-actions.el
@@ -78,27 +78,6 @@ for the whole solution."
                                  "took " (number-to-string time-elapsed-seconds) " seconds to complete.\n"))
                  (setq buffer-read-only t)))))))))
 
-;; TODO create omnisharp-add-to-solution that lets user choose which
-;; file to add.
-(defun omnisharp-add-to-solution-current-file ()
-  (interactive)
-  (let ((params (omnisharp--get-request-object)))
-    (omnisharp-add-to-solution-worker params)
-    (message "Added %s to the solution."
-             (omnisharp--get-filename params))))
-
-(defun omnisharp-add-to-solution-dired-selected-files ()
-  "Add the files currently selected in dired to the current solution."
-  (interactive)
-  (let ((selected-files (dired-get-marked-files)))
-    (--each selected-files
-      (let ((params
-             (cons (omnisharp--to-filename it)
-                   (omnisharp--get-request-object))))
-        (omnisharp-add-to-solution-worker params))
-      (message "Added %s files to the solution."
-               (prin1-to-string (length selected-files))))))
-
 (defun omnisharp-run-code-action-refactoring ()
   "Gets a list of refactoring code actions for the current editor
 position and file from the server. Asks the user what kind of


### PR DESCRIPTION
Currently these functions depend on `omnisharp-add-to-solution-worker` which doesn't exist within omnisharp any more and are therefore broken.

This pr removes these functions.

While technically this is a breaking change due to the fact new project solutions don't require files to be added I think we should be moving towards only supporting that over the longer term anyway.