### PR TITLE
Remove broken interactive rename

### DIFF
--- a/omnisharp-current-symbol-actions.el
+++ b/omnisharp-current-symbol-actions.el
@@ -171,30 +171,4 @@ name to rename to, defaulting to the current name of the symbol."
      (omnisharp--get-filename modified-file-response)
      (omnisharp--vector-to-list changes))))
 
-(defun omnisharp-rename-interactively ()
-  "Rename the current symbol to a new name. Lets the user choose what
-name to rename to, defaulting to the current name of the symbol. Any
-renames require interactive confirmation from the user."
-  (interactive)
-  (let* ((current-word (thing-at-point 'symbol))
-         (rename-to (read-string "Rename to: " current-word))
-         (delimited
-          (y-or-n-p "Only rename full words?"))
-         (all-solution-files
-          (omnisharp--get-solution-files-list-of-strings))
-         (location-before-rename
-          (omnisharp--get-request-object-for-emacs-side-use)))
-
-    (setq omnisharp--current-solution-files all-solution-files)
-    (tags-query-replace current-word
-                        rename-to
-                        delimited
-                        ;; This is expected to be a form that will be
-                        ;; evaluated to get the list of all files to
-                        ;; process.
-                        'omnisharp--current-solution-files)
-    ;; Keep point in the buffer that initialized the rename so that
-    ;; the user deos not feel disoriented
-    (omnisharp-go-to-file-line-and-column location-before-rename)))
-
 (provide 'omnisharp-current-symbol-actions)

--- a/omnisharp-navigation-actions.el
+++ b/omnisharp-navigation-actions.el
@@ -184,14 +184,6 @@ completing-read. Returns the chosen element."
    (-lambda ((&alist 'QuickFixes quickfixes))
             (omnisharp--choose-and-go-to-quickfix-ido quickfixes other-window))))
 
-(defun omnisharp--get-solution-files-list-of-strings ()
-  "Returns all files in the current solution as a list of strings."
-  (->> (omnisharp--get-solution-files-quickfix-response)
-    (assoc 'QuickFixes)
-    (cdr)
-    (omnisharp--vector-to-list)
-    (--map (omnisharp--get-filename it))))
-
 (defun omnisharp-navigate-to-solution-file-then-file-member
   (&optional other-window)
   "Navigates to a file in the solution first, then to a member in that


### PR DESCRIPTION
Seems this is missing `omnisharp--get-solution-files-quickfix-response` as well.

So im assuming we just want to remove this.   If it doesnt handle it already surely omnisharp has a rename refactoring which using roslyn and modified files without needing to be interactive.