### PR TITLE
auto-complete-display-backend 'ido' should use ido

### DIFF
--- a/omnisharp-settings.el
+++ b/omnisharp-settings.el
@@ -201,4 +201,13 @@ boost for completions."
   :type '(choice (const :tag "Yes" t)
                  (const :tag "No" nil)))
 
+(defcustom omnisharp-completing-read-function 'omnisharp-builtin-completing-read
+  "Function to be called when requesting input from the user."
+  :group 'omnisharp
+  :type '(radio (function-item omnisharp-builtin-completing-read)
+                (function-item ido-completing-read)
+                (function-item ivy-completing-read)
+                (function-item helm--completing-read-default)
+                (function :tag "Other function")))
+
 (provide 'omnisharp-settings)

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -295,15 +295,20 @@ changes to be applied to that buffer instead."
       (accept-process-output process 0.1)))
   request-id)
 
+(defun omnisharp-builtin-completing-read (&rest args)
+  "Default completing read. See `omnisharp-completing-read-function'"
+  ;; e.g. ivy and helm don't need a case here, because they set
+  ;; `completing-read-function' in their mode
+  (let ((completing-read-variant (cond ((bound-and-true-p ido-mode) 'ido-completing-read)
+                                       (t 'completing-read))))
+    (apply completing-read-variant args)))
+
 (defun omnisharp--completing-read (&rest args)
   "Mockable wrapper for completing-read.
 The problem with mocking completing-read directly is that
 sometimes the mocks are not removed when an error occurs. This renders
 the developer's emacs unusable."
-  (let ((completing-read-variant (if (and (boundp 'ido-mode) ido-mode)
-                                     'ido-completing-read
-                                   'completing-read)))
-    (apply completing-read-variant args)))
+    (apply omnisharp-completing-read-function args))
 
 (defun omnisharp--read-string (&rest args)
   "Mockable wrapper for read-string, see

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -300,7 +300,10 @@ changes to be applied to that buffer instead."
 The problem with mocking completing-read directly is that
 sometimes the mocks are not removed when an error occurs. This renders
 the developer's emacs unusable."
-  (apply 'completing-read args))
+  (let ((completing-read-variant (if (and (boundp 'ido-mode) ido-mode)
+                                     'ido-completing-read
+                                   'completing-read)))
+    (apply completing-read-variant args)))
 
 (defun omnisharp--read-string (&rest args)
   "Mockable wrapper for read-string, see


### PR DESCRIPTION
The 'ido' backend doesn't actually use ido; it uses the `completing-read` built-in. If the user indicated a preference for ido by enabling 'ido-mode' and setting `omnisharp--auto-complete-display-backend` to 'ido' we might as well use ido.

Implemented by using `ido-completing-read` instead of
`completing-read` if `ido-mode` is enabled. Causes
`ido-completing-read` to be used in unrelated
`omnisharp-run-code-action-refactoring` to select a code
action. People who have ido-mode enabled won't mind