### PR TITLE
Drop support for specifying solution file manually

### DIFF
--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,10 +1,14 @@
-FROM microsoft/dotnet:2.2-sdk
+FROM microsoft/dotnet:2.1-sdk
 
 WORKDIR /usr/src
 
-# Install dependencies
+# We need mono for now as it provides msbuild-16x which is used by omnisharp-roslyn on linux for our test project
 RUN apt-get update \
-    && apt-get install -y git emacs24-nox wget curl make \
+    && apt-get install -y apt-transport-https dirmngr gnupg ca-certificates \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+    && (echo "deb https://download.mono-project.com/repo/debian stable-stretch main" | tee /etc/apt/sources.list.d/mono-official-stable.list) \
+    && apt-get update \
+    && apt-get install -y git emacs24-nox wget curl make mono-devel \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Cask
@@ -13,7 +17,7 @@ ENV PATH /root/.cask/bin:$PATH
 
 # Install sample project's dependencies
 COPY test/MinimalProject test/MinimalProject
-RUN (cd ./test/MinimalProject && dotnet restore)
+RUN (cd ./test/MinimalProject && dotnet build)
 
 # Install omnisharp and it's dependency packages via Cask
 COPY Cask Cask

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.2-sdk
+FROM microsoft/dotnet:2.2-sdk
 
 WORKDIR /usr/src
 

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,23 +1,18 @@
-FROM microsoft/dotnet:2.1-sdk
+FROM mono:5.18
 
 WORKDIR /usr/src
 
-# We need mono for now as it provides msbuild-16x which is used by omnisharp-roslyn on linux for our test project
 RUN apt-get update \
-    && apt-get install -y apt-transport-https dirmngr gnupg ca-certificates \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && (echo "deb https://download.mono-project.com/repo/debian stable-stretch main" | tee /etc/apt/sources.list.d/mono-official-stable.list) \
-    && apt-get update \
-    && apt-get install -y git emacs24-nox wget curl make mono-devel \
+    && apt-get install -y git emacs24-nox curl make python \
     && rm -rf /var/lib/apt/lists/*
+
+# Install sample project's dependencies
+COPY test/MinimalProject test/MinimalProject
+RUN (cd ./test/MinimalProject && nuget restore MinimalProject.csproj && msbuild MinimalProject.csproj)
 
 # Install Cask
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 ENV PATH /root/.cask/bin:$PATH
-
-# Install sample project's dependencies
-COPY test/MinimalProject test/MinimalProject
-RUN (cd ./test/MinimalProject && dotnet build)
 
 # Install omnisharp and it's dependency packages via Cask
 COPY Cask Cask

--- a/omnisharp-server-actions.el
+++ b/omnisharp-server-actions.el
@@ -19,20 +19,16 @@
 
 Will query user for a path to project/solution file to start the server with."
   (let ((server-executable-path (omnisharp--resolve-omnisharp-server-executable-path))
-        (project-file-candidates (omnisharp--resolve-sln-candidates)))
+        (project-root (omnisharp--project-root)))
     (if server-executable-path
         (if (and (not no-autodetect)
-                 project-file-candidates)
-            (omnisharp--do-server-start (completing-read "Omnisharp - Start Server"
-                                                         project-file-candidates
-                                                         nil
-                                                         t))
-          (let ((path-to-project (read-file-name
-                                  "Start OmniSharp for project folder or solution file: ")))
-            (if (file-exists-p path-to-project)
-                (omnisharp--do-server-start path-to-project)
-              (error (format "Path does not lead to a valid project directory or solution file path: %s"
-                             path-to-project))))))))
+                 project-root
+                 (file-directory-p project-root))
+            (omnisharp--do-server-start project-root)
+          (let ((project-root (read-directory-name "Project root to use with OmniSharp: ")))
+            (if (file-directory-p project-root)
+                (omnisharp--do-server-start project-root)
+              (error (format "Path does not lead to a directory: %s" project-root))))))))
 
 (defun omnisharp--stop-server ()
   "Actual implementation for autoloaded omnisharp-stop-server"

--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -89,7 +89,8 @@ to use server installed via `omnisharp-install-server`.
                                       "OmniServer" ; buffer name
                                       server-executable-path
                                       "--encoding" "utf-8"
-                                      "--stdio")))
+                                      "--stdio"
+                                      (if omnisharp-debug "--verbose" ""))))
              (buffer-disable-undo (process-buffer omnisharp-process))
              (set-process-filter omnisharp-process 'omnisharp--handle-server-message)
              (set-process-sentinel omnisharp-process

--- a/omnisharp-settings.el
+++ b/omnisharp-settings.el
@@ -91,7 +91,7 @@ Otherwise omnisharp request the user to do M-x `omnisharp-install-server` and th
 executable will be used instead."
   :type '(choice (const :tag "Not Set" nil) string))
 
-(defcustom omnisharp-expected-server-version "1.32.6"
+(defcustom omnisharp-expected-server-version "1.32.13"
   "Version of the omnisharp-roslyn server that this omnisharp-emacs package
 is built for. Also used to select version for automatic server installation."
   :group 'omnisharp

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -160,6 +160,11 @@ the OmniSharp server understands."
 
 (defun omnisharp--log (single-or-multiline-log-string)
   "Writes message to the log."
+  (when omnisharp-debug
+    (message (concat "*omnisharp-log*: "
+                     (format-time-string "[%H:%M:%S] ")
+                     single-or-multiline-log-string)))
+
   (let ((log-buffer (get-buffer-create "*omnisharp-log*")))
     (save-window-excursion
       (with-current-buffer log-buffer

--- a/omnisharp-utils.el
+++ b/omnisharp-utils.el
@@ -336,31 +336,8 @@ was found. Uses projectile for the job."
   ;; use project root as a candidate (if we have projectile available)
   (if (require 'projectile nil 'noerror)
       (condition-case nil
-          (let ((project-root (projectile-project-root)))
-            (if (not (string= project-root default-directory))
-                project-root))
+          (projectile-project-root)
         (error nil))))
-
-(defun omnisharp--resolve-sln-candidates ()
-  "Resolves a list of .sln file candidates and directories to be used
-for starting a server based on the current buffer."
-  (let ((dir (file-name-directory (or buffer-file-name "")))
-        (candidates nil)
-        (project-root (omnisharp--project-root)))
-    (while (and dir (not (f-root-p dir)))
-      (if (not (file-remote-p dir))
-          (setq candidates (append candidates
-                                   (f-files dir (lambda (filename)
-                                                  (string-match-p "\\.sln$" filename))))))
-      (setq dir (f-parent dir)))
-
-    (setq candidates (reverse candidates))
-
-    ;; use project root as a candidate (if we have projectile available)
-    (if project-root
-        (setq candidates (append candidates (list project-root))))
-
-    candidates))
 
 (defun omnisharp--buffer-contains-metadata()
   "Returns t if buffer is omnisharp metadata buffer."

--- a/test-stuff/run-integration-tests.sh
+++ b/test-stuff/run-integration-tests.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 
-echo "'dotnet --version' reports:" $(dotnet --version)
-
-if [[ $(dotnet --version) != "2.1"* ]]; then
-    echo "Must install the .NET CLI 2.1.* http://dotnet.github.io/"
-    exit 1
-fi
-
-if [[ ! -r test/MinimalProject/project.lock.json ]]; then
-    echo "Restoring MinimalProject packages"
-    pushd test/MinimalProject
-    dotnet restore
-    popd
-fi
-
 TERM=dumb SHELL=sh cask exec emacs \
     -Q \
     -batch \

--- a/test-stuff/run-integration-tests.sh
+++ b/test-stuff/run-integration-tests.sh
@@ -2,8 +2,8 @@
 
 echo "'dotnet --version' reports:" $(dotnet --version)
 
-if [[ $(dotnet --version) != "1.1"* ]]; then
-    echo "Must install the .NET CLI 1.1.* http://dotnet.github.io/"
+if [[ $(dotnet --version) != "2.2"* ]]; then
+    echo "Must install the .NET CLI 2.2.* http://dotnet.github.io/"
     exit 1
 fi
 

--- a/test-stuff/run-integration-tests.sh
+++ b/test-stuff/run-integration-tests.sh
@@ -2,8 +2,8 @@
 
 echo "'dotnet --version' reports:" $(dotnet --version)
 
-if [[ $(dotnet --version) != "2.2"* ]]; then
-    echo "Must install the .NET CLI 2.2.* http://dotnet.github.io/"
+if [[ $(dotnet --version) != "2.1"* ]]; then
+    echo "Must install the .NET CLI 2.1.* http://dotnet.github.io/"
     exit 1
 fi
 

--- a/test/MinimalProject/MinimalProject.csproj
+++ b/test/MinimalProject/MinimalProject.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>MinimalProject</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>MinimalProject</PackageId>

--- a/test/MinimalProject/MinimalProject.csproj
+++ b/test/MinimalProject/MinimalProject.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>MinimalProject</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>MinimalProject</PackageId>
-    <RuntimeFrameworkVersion>1.1.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/test/MinimalProject/MinimalProject.csproj
+++ b/test/MinimalProject/MinimalProject.csproj
@@ -1,8 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssemblyName>MinimalProject</AssemblyName>
-    <OutputType>Exe</OutputType>
-    <PackageId>MinimalProject</PackageId>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/test/MinimalProject/MyClass.cs
+++ b/test/MinimalProject/MyClass.cs
@@ -1,5 +1,10 @@
-using System;
-namespace minimal
-{
-    public class MyClass {}
+namespace MyNamespace {
+    public class Class321
+    {
+        public void Whatever()
+        {
+            IPAddress.Parse();
+            Gu$id.NewGuid();
+        }
+    }
 }

--- a/test/MinimalProject/MyClass.cs
+++ b/test/MinimalProject/MyClass.cs
@@ -1,10 +1,12 @@
-namespace MyNamespace {
-    public class Class321
+using System;
+
+namespace minimal
+{
+    public class MyClass
     {
-        public void Whatever()
+        public static void Main(string[] args)
         {
-            IPAddress.Parse();
-            Gu$id.NewGuid();
+            Console.WriteLine("hello, world");
         }
     }
 }

--- a/test/buttercup-tests/flycheck/flycheck-test.el
+++ b/test/buttercup-tests/flycheck/flycheck-test.el
@@ -28,7 +28,7 @@
     ;; open error list and verify its contents
     (flycheck-list-errors)
 
-    (ot--switch-to-the-window-in-the-buffer "*Flycheck errors* for buffer FlycheckTest.cs")
+    (ot--switch-to-the-window-in-the-buffer "*Flycheck errors*")
     (ot--point-should-be-on-a-line-containing
      (concat "The type or namespace name 'DoesNotExist' could not be found"
              " (are you missing a using directive or an assembly reference?)"))

--- a/test/buttercup-tests/flycheck/flycheck-test.el
+++ b/test/buttercup-tests/flycheck/flycheck-test.el
@@ -28,7 +28,7 @@
     ;; open error list and verify its contents
     (flycheck-list-errors)
 
-    (ot--switch-to-the-window-in-the-buffer "*Flycheck errors*")
+    (ot--switch-to-the-window-in-the-buffer "*Flycheck errors* for buffer FlycheckTest.cs")
     (ot--point-should-be-on-a-line-containing
      (concat "The type or namespace name 'DoesNotExist' could not be found"
              " (are you missing a using directive or an assembly reference?)"))

--- a/test/buttercup-tests/navigation/go-to-definition-test.el
+++ b/test/buttercup-tests/navigation/go-to-definition-test.el
@@ -79,5 +79,5 @@
       ;; TODO: for some reason I need to set current buffer from window list
       ;;       with with-current-buffer..
       (with-current-buffer (car (mapcar #'window-buffer (window-list)))
-        (ot--i-should-be-in-buffer-name "*omnisharp-metadata:MinimalProject:System.Runtime:System.String*")
+        (ot--i-should-be-in-buffer-name "*omnisharp-metadata:MiscellaneousFiles.csproj:mscorlib:System.String*")
         (ot--point-should-be-on-a-line-containing "public sealed class String"))))

--- a/test/buttercup-tests/setup.el
+++ b/test/buttercup-tests/setup.el
@@ -92,6 +92,10 @@ request id."
   (beginning-of-buffer)
   (search-forward "$")
   (delete-backward-char 1)
+  (message (concat "ot--buffer-contents-and-point-at-$: (thing-at-point 'word) is: "
+                   (thing-at-point 'word)))
+  (message (concat "ot--buffer-contents-and-point-at-$: (thing-at-point 'line) is: "
+                   (thing-at-point 'line)))
   ;; will block
   (omnisharp--update-buffer)
   (when (fboundp 'evil-insert)

--- a/test/buttercup-tests/solution/code-actions/fix-code-issue-test.el
+++ b/test/buttercup-tests/solution/code-actions/fix-code-issue-test.el
@@ -4,18 +4,23 @@
 ;; each one in a sensible manner.
 (describe "Fix code issue"
   (before-each (ot--open-the-minimal-project-source-file "MyClass.cs"))
-  (it "can act on a simple part of the buffer (using System;)"
+  (it "can act on a simple part of the buffer (using System.Net;)"
     (ot--buffer-contents-and-point-at-$
-     "public class Class1"
+     "namespace MyNamespace"
      "{"
-     "    public void Whatever()"
+     "    public class MyClass"
      "    {"
-     "        Gu$id.NewGuid();"
+     "        public void Whatever()"
+     "        {"
+     "            IPAddress.Par$se(\"1.2.3.4\");"
+     "        }"
      "    }"
      "}")
-    (ot--answer-omnisharp--completing-read-with (lambda (choices) "using System;"))
+    (ot--answer-omnisharp--completing-read-with (lambda (choices)
+                                                  (message (concat "the choices are: " (json-encode choices)))
+                                                  "using System.Net;"))
     (omnisharp--wait-until-request-completed (omnisharp-run-code-action-refactoring))
-    (ot--buffer-should-contain "using System;"))
+    (ot--buffer-should-contain "using System.Net;"))
 
   (it "can operate on the current region (Extract method)"
     (ot--buffer-contents-and-region

--- a/test/buttercup-tests/solution/solution-errors-test.el
+++ b/test/buttercup-tests/solution/solution-errors-test.el
@@ -30,7 +30,6 @@
 
     (ot--switch-to-the-window-in-the-buffer "*omnisharp-solution-errors*")
 
-    (ot--buffer-should-contain "MyClass.cs(1,1): warning CS8019: Unnecessary using directive.")
     (ot--buffer-should-contain "MyClass.cs(6,14): error CS1519: Invalid token '-' in class, struct, or interface member declaration")
     (ot--buffer-should-contain "MyClass.cs(7,5): error CS1519: Invalid token '}' in class, struct, or interface member declaration")
     (ot--buffer-should-contain "omnisharp-solution-errors: finished")))


### PR DESCRIPTION
Hopefully this makes the experience more seamless and in line with other implementations where e.g. in VSCode you don't have to specify project root, but .git root is used instead.

Uses projectile (if available) to resolve project directory.

Related to #473 