### PR TITLE
Linux arm server install

### DIFF
--- a/omnisharp-server-installation.el
+++ b/omnisharp-server-installation.el
@@ -52,7 +52,7 @@
       (let ((powershell-version (substring
                                  (shell-command-to-string "powershell -command \"(Get-Host).Version.Major\"")
                                  0 -1)))
-        (If (>= (string-to-number powershell-version) 5)
+        (if (>= (string-to-number powershell-version) 5)
             (call-process "powershell"
                           nil
                           nil

--- a/omnisharp-server-installation.el
+++ b/omnisharp-server-installation.el
@@ -52,7 +52,7 @@
       (let ((powershell-version (substring
                                  (shell-command-to-string "powershell -command \"(Get-Host).Version.Major\"")
                                  0 -1)))
-        (if (>= (string-to-number powershell-version) 5)
+        (If (>= (string-to-number powershell-version) 5)
             (call-process "powershell"
                           nil
                           nil
@@ -76,7 +76,9 @@ Note that due to a bug in emacs on Windows we currently use the x86/32bit versio
 See https://github.com/OmniSharp/omnisharp-emacs/issues/315"
   (cond ((eq system-type 'windows-nt) "omnisharp-win-x86.zip")
         ((eq system-type 'darwin) "omnisharp-osx.tar.gz")
-        ((eq system-type 'gnu/linux) "omnisharp-linux-x64.tar.gz")
+        ((and (eq system-type 'gnu/linux)
+	      (or (eq (string-match "^x86_64" system-configuration) 0)
+	      (eq (string-match "^i[3-6]86" system-configuration) 0))) "omnisharp-linux-x64.tar.gz")
         (t "omnisharp-mono.tar.gz")))
 
 (defun omnisharp--install-server (reinstall &rest silent-installation)


### PR DESCRIPTION
Added logic to check the processor architecture of Emacs and only pull the x64 Omnisharp server if Emacs is an Intel architecture (x86/x64) on Linux. Otherwise, it will use Mono (Android and Raspberry Pi). This does not fix the proot problem because that is an issue with the core Emacs filesystem functions unrelated to Omnisharp-Emacs.