### PR TITLE
fix server root directory on cygwin

### DIFF
--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -83,7 +83,7 @@ to use server installed via `omnisharp-install-server`.
           (make-omnisharp--server-info
            ;; use a pipe for the connection instead of a pty
            (let* ((process-connection-type nil)
-                  (default-directory (omnisharp--path-to-server (expand-file-name project-root)))
+                  (default-directory (expand-file-name project-root))
                   (omnisharp-process (start-process
                                       "OmniServer" ; process name
                                       "OmniServer" ; buffer name


### PR DESCRIPTION
Converting the path to server format resulted in errors like:

> omnisharp: starting server on project root: "/e/dev/"
> apply: Setting current directory: No such file or directory, E:\dev\

This path isn't actually sent to the server, so it shouldn't be converted.