### PR TITLE
Fix #507: Optional `add-to-kill-ring' parameter not passed to `omnisharp-current-type-information-worker'

### DIFF
--- a/omnisharp-current-symbol-actions.el
+++ b/omnisharp-current-symbol-actions.el
@@ -25,7 +25,7 @@ to insert the result in code, for example."
 argument, add the displayed result to the kill ring. This can be used
 to insert the result in code, for example."
   (interactive "P")
-  (omnisharp-current-type-information-worker 'Documentation))
+  (omnisharp-current-type-information-worker 'Documentation add-to-kill-ring))
 
 (defun omnisharp-current-type-information-worker (type-property-name
                                                   &optional add-to-kill-ring)


### PR DESCRIPTION
Sorry it took so long, I had opened the PR on my own repository instead of yours.