### PR TITLE
Upgrade omnisharp server version to 1.37.1.

### DIFF
--- a/omnisharp-settings.el
+++ b/omnisharp-settings.el
@@ -91,7 +91,7 @@ Otherwise omnisharp request the user to do M-x `omnisharp-install-server` and th
 executable will be used instead."
   :type '(choice (const :tag "Not Set" nil) string))
 
-(defcustom omnisharp-expected-server-version "1.34.5"
+(defcustom omnisharp-expected-server-version "1.37.1"
   "Version of the omnisharp-roslyn server that this omnisharp-emacs package
 is built for. Also used to select version for automatic server installation."
   :group 'omnisharp


### PR DESCRIPTION
The previous version was set to 1.34.5.
With this update `omnisharp-roslyn` is finally able to load my Unity projects.