### PR TITLE
omnisharp-server-management.el: use non-anomorphic version of -filter…

### DIFF
--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -4,7 +4,7 @@ WORKDIR /usr/src
 
 # Install dependencies
 RUN apt-get update \
-    && apt-get install -y git emacs25-nox curl make \
+    && apt-get install -y git emacs26-nox curl make \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Cask

--- a/omnisharp-server-management.el
+++ b/omnisharp-server-management.el
@@ -349,7 +349,7 @@ have not been returned before."
             ;; debugging, as they can slow emacs down when they pile
             ;; up
             (when (not omnisharp-debug) (erase-buffer))
-            (-map trim-bom (--filter (not (s-blank? it)) text))))))))
+            (-map trim-bom (-filter (lambda (s)(not (s-blank? s))) text))))))))
 
 (defun omnisharp--attempt-to-start-server-for-buffer ()
   "Checks if the server for the project of the buffer is running


### PR DESCRIPTION
… in omnisharp--read-lines-from-process-output

This may help us avoid `(void-variable it)` error when running under emacs28+nativecomp

An attempt to fix #521