### PR TITLE
Ignore csharp-mode on new emacs version

### DIFF
--- a/omnisharp.el
+++ b/omnisharp.el
@@ -32,7 +32,7 @@
 
 (require 'cl)
 (require 'cl-lib)
-(require 'csharp-mode)
+(unless (version< "29" emacs-version) (require 'csharp-mode))
 (require 'json)
 (require 'files)
 (require 'ido)


### PR DESCRIPTION
Refer to https://github.com/emacs-csharp/csharp-mode/blob/02c61c219b2c22491eff9b7315fed661fab423d4/csharp-mode.el#L40-L42, we do not need csharp-mode any more on new emacs versions. Ignore the dependency could avoid the warn message.